### PR TITLE
feat: Add DISABLE_LEECH Option

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -17,6 +17,7 @@ class Config:
     DEFAULT_UPLOAD = "rc"
     DELETE_LINKS = False
     DISABLE_TORRENTS = False
+    DISABLE_LEECH = False
     EQUAL_SPLITS = False
     EXCLUDED_EXTENSIONS = ""
     FFMPEG_CMDS = {}

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -2,6 +2,7 @@ from base64 import b64encode
 from re import match as re_match
 
 from aiofiles.os import path as aiopath
+from bot.core.config_manager import Config
 
 from .. import DOWNLOAD_DIR, LOGGER, bot_loop, task_dict_lock
 from ..helper.ext_utils.bot_utils import (
@@ -419,6 +420,9 @@ async def nzb_mirror(client, message):
 
 
 async def leech(client, message):
+    if Config.DISABLE_LEECH:
+        await message.reply("The Leech command is currently disabled.")
+        return
     bot_loop.create_task(Mirror(client, message, is_leech=True).new_event())
 
 

--- a/config_sample.py
+++ b/config_sample.py
@@ -34,8 +34,9 @@ HELPER_TOKENS = ""
 MEGA_EMAIL = ""
 MEGA_PASSWORD = ""
 
-# Disable Torrent
+# Disable Options
 DISABLE_TORRENTS = False
+DISABLE_LEECH = False
 
 # Telegraph
 AUTHOR_NAME = "WZML-X"


### PR DESCRIPTION
## Summary by Sourcery

Add a new configuration option to disable the leech command and enforce it at runtime

New Features:
- Introduce a DISABLE_LEECH flag in the configuration manager and sample config
- Add a pre-check in the leech command to block execution and notify users when DISABLE_LEECH is enabled