### PR TITLE
feat: Implement YouTube folder to playlist uploads

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -369,18 +369,28 @@ class TaskListener(TaskConfig):
         )
         LOGGER.info(f"Task Done: {self.name}")
         if self.is_yt:
-            msg += "\n<b>Type: </b>Video"
-            if link:
-                msg += f"\n<b>Video Link: </b><a href='{link}'>YouTube</a>"
-            msg += f"\n\n<b>cc: </b>{self.tag}"
+            buttons = ButtonMaker()
+            if mime_type == "Folder/Playlist":
+                msg += f"\n┠ <b>Type</b> → Playlist"
+                msg += f"\n┖ <b>Total Videos</b> → {files}"
+                if link:
+                    buttons.url_button("🔗 View Playlist", link)
+                user_message = f"{self.tag}\nYour playlist ({files} videos) has been uploaded to YouTube successfully!"
+            else:
+                msg += f"\n┖ <b>Type</b> → Video"
+                if link:
+                    buttons.url_button("🔗 View Video", link)
+                user_message = f"{self.tag}\nYour video has been uploaded to YouTube successfully!"
 
-            await send_message(self.user_id, msg)
+            msg += f"\n\n<b>Task By: </b>{self.tag}"
+
+            button = buttons.build_menu(1) if link else None
+
+            await send_message(self.user_id, msg, button)
             if Config.LEECH_DUMP_CHAT:
-                await send_message(int(Config.LEECH_DUMP_CHAT), msg)
-            await send_message(
-                self.message,
-                f"{self.tag}\nYour video has been uploaded to YouTube successfully!",
-            )
+                await send_message(int(Config.LEECH_DUMP_CHAT), msg, button)
+            await send_message(self.message, user_message, button)
+
         elif self.is_leech:
             msg += f"\n<b>Total Files: </b>{folders}"
             if mime_type != 0:

--- a/bot/helper/mirror_leech_utils/youtube_utils/youtube_upload.py
+++ b/bot/helper/mirror_leech_utils/youtube_utils/youtube_upload.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 from logging import getLogger
 from os import path as ospath
 from os import remove
@@ -25,10 +26,36 @@ class YouTubeUpload(YouTubeHelper):
     def __init__(self, listener, path):
         self.listener = listener
         self._updater = None
-        self._path = path
+        self.path = path
         self._is_errored = False
         super().__init__()
         self.is_uploading = True
+        self.is_folder_upload = False
+        self.video_files = []
+        self.total_files = 0
+        self.size = 0
+
+        if ospath.isdir(self.path):
+            self.is_folder_upload = True
+            self.name = ospath.basename(self.path)
+            for root, _, files in os.walk(self.path):
+                for file in files:
+                    file_path = ospath.join(root, file)
+                    self.video_files.append(file_path)
+                    self.size += ospath.getsize(file_path)
+            self.total_files = len(self.video_files)
+            if not self.video_files:
+                LOGGER.warning(f"No video files found in folder: {self.path}")
+        elif ospath.isfile(self.path):
+            self.is_folder_upload = False
+            self.name = listener.name
+            self.size = ospath.getsize(self.path)
+            self.video_files = []
+            self.total_files = 1
+        else:
+            raise ValueError(f"Invalid path: {self.path} is not a file or directory.")
+
+        self._path = self.path
 
     def user_setting(self):
         """Handle user-specific YouTube token settings"""
@@ -52,31 +79,68 @@ class YouTubeUpload(YouTubeHelper):
             )
             return
 
-        LOGGER.info(f"Uploading to YouTube: {self._path}")
+        LOGGER.info(f"Uploading to YouTube: {self.name}")
         self._updater = SetInterval(self.update_interval, self.progress)
         video_url = None
+        playlist_url = None
 
         try:
-            if ospath.isfile(self._path):
-                mime_type = get_mime_type(self._path)
+            if self.is_folder_upload:
+                if not self.video_files:
+                    raise ValueError(
+                        f"No video files found to upload in folder: {self.name}"
+                    )
 
-                # Check if file is a video
-                if not mime_type.startswith("video/"):
-                    raise ValueError(f"File is not a video. MIME type: {mime_type}")
-
-                video_url = self._upload_video(
-                    self._path, self.listener.name, mime_type
+                playlist_id = self._create_playlist(
+                    self.name, Config.YT_PRIVACY_STATUS, Config.YT_DESP
                 )
+                if not playlist_id:
+                    raise ValueError("Failed to create playlist.")
+
+                playlist_url = f"https://www.youtube.com/playlist?list={playlist_id}"
+                LOGGER.info(f"Created playlist: {self.name} - {playlist_url}")
+
+                for video_path in self.video_files:
+                    if self.listener.is_cancelled:
+                        LOGGER.info("Upload cancelled by user during folder upload.")
+                        break
+
+                    video_title = ospath.splitext(ospath.basename(video_path))[0]
+                    current_video_url = self._upload_video(
+                        video_path, video_title, get_mime_type(video_path), playlist_id
+                    )
+                    if not current_video_url:
+                        LOGGER.error(f"Failed to upload video: {video_path}")
+                        self._is_errored = True
+                    else:
+                        LOGGER.info(
+                            f"Uploaded video to playlist: {video_title} - {current_video_url}"
+                        )
 
                 if self.listener.is_cancelled:
                     return
 
-                if video_url is None:
-                    raise ValueError("Upload has been manually cancelled")
+                if not self._is_errored and not self.video_files:
+                    raise ValueError(
+                        f"No compatible video files were uploaded from folder: {self.name}"
+                    )
 
-                LOGGER.info(f"Uploaded To YouTube: {self._path}")
+            elif ospath.isfile(self.path):
+                video_url = self._upload_video(self.path, self.name, get_mime_type(self.path))
+
+                if self.listener.is_cancelled:
+                    return
+
+                if video_url is None and not self.listener.is_cancelled:
+                    raise ValueError(
+                        "Upload failed or was cancelled, no video URL returned."
+                    )
+
+                if video_url:
+                    LOGGER.info(f"Uploaded To YouTube: {self.name} - {video_url}")
             else:
-                raise ValueError("YouTube only supports single video file uploads")
+
+                raise ValueError(f"Invalid path type for upload: {self.path}")
 
         except Exception as err:
             if isinstance(err, RetryError):
@@ -90,36 +154,89 @@ class YouTubeUpload(YouTubeHelper):
             self._updater.cancel()
 
         if self.listener.is_cancelled and not self._is_errored:
+            LOGGER.info("Upload process cancelled.")
             return
 
-        if self._is_errored:
+        if self._is_errored and not self.is_folder_upload:
             return
 
-        async_to_sync(
-            self.listener.on_upload_complete,
-            video_url,
-            1,  # total_files
-            0,  # total_folders
-            "Video",  # mime_type
-        )
+        if self._is_errored and self.is_folder_upload:
+
+            pass
+
+        if self.is_folder_upload:
+            if not self.video_files and not playlist_url:
+                async_to_sync(
+                    self.listener.on_upload_error,
+                    f"No video files found in {self.name}",
+                )
+                return
+
+            if (
+                self._is_errored
+                and playlist_url
+                and not any(ospath.exists(v_path) for v_path in self.video_files)
+            ):
+
+                pass
+
+            async_to_sync(
+                self.listener.on_upload_complete,
+                playlist_url,
+                self.total_files,
+                0,
+                "Folder/Playlist",
+            )
+        elif video_url:
+            async_to_sync(
+                self.listener.on_upload_complete,
+                video_url,
+                1,
+                0,
+                get_mime_type(self.path) or "Video",
+            )
+
         return
+
+    def _create_playlist(self, title, privacy_status="public", description=""):
+        """Creates a YouTube playlist."""
+        try:
+            body = {
+                "snippet": {
+                    "title": title,
+                    "description": description,
+                },
+                "status": {"privacyStatus": privacy_status},
+            }
+            response = (
+                self.service.playlists()
+                .insert(part="snippet,status", body=body)
+                .execute()
+            )
+            LOGGER.info(f"Playlist created: {response['id']}")
+            return response["id"]
+        except HttpError as e:
+            LOGGER.error(f"Failed to create playlist: {e}")
+            return None
+        except Exception as e:
+            LOGGER.error(f"An unexpected error occurred while creating playlist: {e}")
+            return None
 
     @retry(
         wait=wait_exponential(multiplier=2, min=3, max=6),
         stop=stop_after_attempt(3),
         retry=retry_if_exception_type(Exception),
     )
-    def _upload_video(self, file_path, file_name, mime_type):
-        """Upload video to YouTube"""
+    def _upload_video(self, file_path, file_name, mime_type, playlist_id=None):
+        """Upload video to YouTube and optionally add to a playlist."""
 
-        # Default video metadata
         title = file_name
         description = Config.YT_DESP
         tags = Config.YT_TAGS
         category_id = Config.YT_CATEGORY_ID
         privacy_status = Config.YT_PRIVACY_STATUS
 
-        body = {
+        video_body = {
             "snippet": {
                 "title": title,
                 "description": description,
@@ -132,61 +249,101 @@ class YouTubeUpload(YouTubeHelper):
             },
         }
 
-        # Create media upload object
         media_body = MediaFileUpload(
-            file_path,
-            mimetype=mime_type,
-            resumable=True,
-            chunksize=1024 * 1024 * 4,  # 4MB chunks
+            file_path, mimetype=mime_type, resumable=True, chunksize=1024 * 1024 * 4
         )
 
-        # Create the upload request
         insert_request = self.service.videos().insert(
-            part=",".join(body.keys()), body=body, media_body=media_body
+            part=",".join(video_body.keys()), body=video_body, media_body=media_body
         )
 
-        response = None
+        video_response = None
         retries = 0
+        current_chunk_uploaded_bytes = 0
 
-        while response is None and not self.listener.is_cancelled:
+        while video_response is None and not self.listener.is_cancelled:
             try:
-                self.status, response = insert_request.next_chunk()
+                prev_progress_bytes = current_chunk_uploaded_bytes
+                self.status, video_response = insert_request.next_chunk()
+
                 if self.status:
-                    self.upload_progress = int(self.status.progress() * 100)
-                    LOGGER.info(f"Upload progress: {self.upload_progress}%")
+                    current_video_total_size = ospath.getsize(file_path)
+                    current_chunk_uploaded_bytes = self.status.resumable_progress
+
+                    if current_video_total_size > 0:
+                        self.upload_progress = int(
+                            (current_chunk_uploaded_bytes / current_video_total_size)
+                            * 100
+                        )
+                    else:
+                        self.upload_progress = (
+                            100 if current_chunk_uploaded_bytes > 0 else 0
+                        )
+
+                    LOGGER.info(f"Uploading '{title}': {self.upload_progress}%")
 
             except HttpError as err:
+
                 if err.resp.status in [500, 502, 503, 504, 429] and retries < 5:
                     retries += 1
                     LOGGER.warning(
-                        f"HTTP error {err.resp.status}, retrying... ({retries}/5)"
+                        f"HTTP error {err.resp.status} for '{title}', retrying... ({retries}/5)"
                     )
                     continue
                 error_content = (
                     err.content.decode("utf-8") if err.content else "Unknown error"
                 )
-                LOGGER.error(f"YouTube upload failed: {error_content}")
+                LOGGER.error(f"YouTube upload failed for '{title}': {error_content}")
                 raise err
             except Exception as e:
-                LOGGER.error(f"Unexpected error during upload: {e}")
+                LOGGER.error(f"Unexpected error during upload of '{title}': {e}")
                 raise e
 
         if self.listener.is_cancelled:
+            LOGGER.info(f"Upload of '{title}' cancelled by user.")
             return None
 
-        # Clean up the file after successful upload
-        with contextlib.suppress(Exception):
-            remove(file_path)
-
-        self.file_processed_bytes = 0
-        self.total_files += 1
-
-        if response:
-            video_id = response["id"]
+        if video_response:
+            video_id = video_response["id"]
             video_url = f"https://www.youtube.com/watch?v={video_id}"
-            LOGGER.info(f"Video uploaded successfully: {video_url}")
+            LOGGER.info(f"Video '{title}' uploaded successfully: {video_url}")
+
+            if playlist_id:
+                try:
+                    playlist_item_body = {
+                        "snippet": {
+                            "playlistId": playlist_id,
+                            "resourceId": {
+                                "kind": "youtube#video",
+                                "videoId": video_id,
+                            },
+                        }
+                    }
+                    self.service.playlistItems().insert(
+                        part="snippet", body=playlist_item_body
+                    ).execute()
+                    LOGGER.info(f"Video '{title}' added to playlist.")
+                except HttpError as e:
+                    LOGGER.error(f"Failed to add video '{title}' to playlist: {e}")
+
+                except Exception as e:
+                    LOGGER.error(
+                        f"An unexpected error occurred while adding video '{title}' to playlist: {e}"
+                    )
+
+            with contextlib.suppress(Exception):
+                remove(file_path)
+
             return video_url
-        raise ValueError("Upload completed but no response received")
+
+        if not self.listener.is_cancelled:
+            LOGGER.error(
+                f"Upload of '{title}' completed but no response received and not cancelled."
+            )
+            raise ValueError(
+                f"Upload of '{title}' gave no response and was not cancelled."
+            )
+        return None
 
     def get_upload_status(self):
         return {


### PR DESCRIPTION
## Summary by Sourcery

Add support for uploading a folder of videos to YouTube as a playlist by scanning the directory, creating a playlist, uploading each video sequentially, and updating user notifications with playlist details.

New Features:
- Detect directory paths and treat them as batch uploads of videos
- Create a new YouTube playlist for folder uploads and add each video file to it
- Extend the upload logic to accept an optional playlist ID and sequentially upload multiple videos into a playlist
- Update the task listener to format messages and buttons for playlist uploads, showing total video count

Enhancements:
- Improve per-video upload progress logging and handle automatic file cleanup after successful upload