### PR TITLE
Minor Update

### DIFF
--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -31,6 +31,7 @@ from .tg_client import TgClient
 from .torrent_manager import TorrentManager
 from ..helper.ext_utils.bot_utils import parse_excluded_extensions
 
+
 async def update_qb_options():
     if not qbit_options:
         if not TorrentManager.qbittorrent:


### PR DESCRIPTION
## Summary by Sourcery

Implement detailed per-stream metadata mapping by integrating ffprobe-based stream detection and constructing ffmpeg commands to preserve and tag individual streams, replacing the previous blanket metadata approach.

New Features:
- Add get_streams helper to fetch media stream information via ffprobe
- Map and copy individual video, audio, and subtitle streams and apply metadata (including language tags) per stream

Enhancements:
- Clear global metadata and apply metadata maps per stream
- Configure ffmpeg thread usage dynamically based on CPU count
- Log and skip files when stream retrieval fails to improve robustness

Documentation:
- Document get_streams function with a detailed docstring

Chores:
- Import parse_excluded_extensions in startup module