### PR TITLE
fix: Validate layout parameter in thumbnail function

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -317,11 +317,15 @@ async def get_video_thumbnail(video_file, duration):
 
 
 async def get_multiple_frames_thumbnail(video_file, layout, keep_screenshots):
-    layout = re.sub(r'(\d+)\D+(\d+)', r'\1x\2', layout)
+    layout = re.sub(r"(\d+)\D+(\d+)", r"\1x\2", layout)
     ss_nb = layout.split("x")
     if len(ss_nb) != 2 or not ss_nb[0].isdigit() or not ss_nb[1].isdigit():
-        raise ValueError(f"Invalid layout value: {layout}")
+        LOGGER.error(f"Invalid layout value: {layout}")
+        return None
     ss_nb = int(ss_nb[0]) * int(ss_nb[1])
+    if ss_nb == 0:
+        LOGGER.error(f"Invalid layout value: {layout}")
+        return None
     dirpath = await take_ss(video_file, ss_nb)
     if not dirpath:
         return None


### PR DESCRIPTION
## Summary by Sourcery

Validate the layout parameter in get_multiple_frames_thumbnail to ensure it follows the 'widthxheight' format with numeric, non-zero values and log an error and return None on invalid input

Bug Fixes:
- Validate that layout splits into exactly two numeric parts
- Reject zero dimensions by checking that the product of layout values is non-zero