### PR TITLE
fix: added default vars ...

### DIFF
--- a/bot/helper/ext_utils/task_manager.py
+++ b/bot/helper/ext_utils/task_manager.py
@@ -268,13 +268,13 @@ async def pre_task_check(message):
         msg.append(
             f"┠ <b>Waiting Time</b> → {get_readable_time(ut)}\n┠ <i>User's Time Interval Restrictions</i> → {get_readable_time(uti)}"
         )
-    bmax_tasks = int(Config.BOT_MAX_TASKS)
+    bmax_tasks = int(Config.BOT_MAX_TASKS or 0)
     if bmax_tasks > 0 and len(await get_specific_tasks("All", False)) >= bmax_tasks:
         msg.append(
             f"┠ Max Concurrent Bot's Tasks Limit exceeded.\n┠ Bot Tasks Limit : {bmax_tasks} task"
         )
 
-    maxtask = int(Config.USER_MAX_TASKS)
+    maxtask = int(Config.USER_MAX_TASKS or 0)
     if maxtask > 0 and len(await get_specific_tasks("All", user_id)) >= maxtask:
         msg.append(
             f"┠ Max Concurrent User's Task(s) Limit exceeded! \n┠ User Task Limit : {maxtask} tasks"

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -66,7 +66,13 @@ DEFAULT_VALUES = {
     "SEARCH_LIMIT": 0,
     "UPSTREAM_BRANCH": "master",
     "DEFAULT_UPLOAD": "rc",
+    "BOT_MAX_TASKS": 0,
+    "QUEUE_ALL": 0,
+    "QUEUE_DOWNLOAD": 0,
+    "QUEUE_UPLOAD": 0,
+    "USER_MAX_TASKS": 0,
 }
+
 
 
 async def get_buttons(key=None, edit_type=None, edit_mode=False):


### PR DESCRIPTION
## Summary by Sourcery

Provide default task and queue limit configurations and ensure pre_task_check safely handles missing values by defaulting to zero

Bug Fixes:
- Wrap Config.BOT_MAX_TASKS and Config.USER_MAX_TASKS with a fallback to 0 before int conversion in pre_task_check to prevent errors when unset

Enhancements:
- Add BOT_MAX_TASKS, USER_MAX_TASKS, QUEUE_ALL, QUEUE_DOWNLOAD, and QUEUE_UPLOAD settings with default 0 values in bot_settings