### PR TITLE
fix: ffmpeg cmd run for single file processing

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -738,9 +738,10 @@ class TaskConfig:
                         await cpu_eater_lock.acquire()
                         self.progress = True
                     LOGGER.info(f"Running ffmpeg cmd for: {file_path}")
-                    cmd[index + 1] = file_path
+                    var_cmd = cmd.copy()
+                    var_cmd[index + 1] = file_path
                     self.subsize = self.size
-                    res = await ffmpeg.ffmpeg_cmds(cmd, file_path)
+                    res = await ffmpeg.ffmpeg_cmds(var_cmd, file_path)
                     if res:
                         if delete_files:
                             await remove(file_path)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent in-place mutation of the shared ffmpeg command list by copying before modifying for each file invocation