### PR TITLE
fix: IMDB Search 

### DIFF
--- a/bot/modules/imdb.py
+++ b/bot/modules/imdb.py
@@ -26,7 +26,7 @@ def _retrieve_patched(self, url, size=-1, _noCookies=False):
         response.raise_for_status()
         return response.text
     except Exception as e:
-        raise e
+        raise
 
 IMDbHTTPAccessSystem._retrieve = _retrieve_patched
 

--- a/bot/modules/imdb.py
+++ b/bot/modules/imdb.py
@@ -1,7 +1,9 @@
 from contextlib import suppress
 from re import IGNORECASE, findall, search
 
+import cloudscraper
 from imdb import Cinemagoer
+from imdb.parser.http import IMDbHTTPAccessSystem
 from pycountry import countries as conn
 from pyrogram.errors import MediaEmpty, PhotoInvalidDimensions, WebpageMediaEmpty
 
@@ -14,6 +16,19 @@ from ..helper.telegram_helper.message_utils import (
     edit_message,
     delete_message,
 )
+
+# Monkeypatch IMDbHTTPAccessSystem._retrieve to use cloudscraper
+scraper = cloudscraper.create_scraper()
+
+def _retrieve_patched(self, url, size=-1, _noCookies=False):
+    try:
+        response = scraper.get(url)
+        response.raise_for_status()
+        return response.text
+    except Exception as e:
+        raise e
+
+IMDbHTTPAccessSystem._retrieve = _retrieve_patched
 
 imdb = Cinemagoer()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ anytree
 apscheduler
 aioaria2
 aioqbt
-cinemagoer
+git+https://github.com/cinemagoer/cinemagoer
 cloudscraper
 dnspython
 fastapi


### PR DESCRIPTION
## Summary by Sourcery

Patch Cinemagoer's HTTP retrieval to use cloudscraper and update dependencies to restore IMDB search functionality

Bug Fixes:
- Override Cinemagoer’s internal _retrieve method to use cloudscraper for HTTP requests and bypass Cloudflare

Build:
- Replace the cinemagoer PyPI package with the GitHub repository version and add cloudscraper as a dependency