### PR TITLE
feat: Add Gofile DDL Support

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -29,6 +29,8 @@ class Config:
     FILELION_API = ""
     MEDIA_STORE = True
     FORCE_SUB_IDS = ""
+    GOFILE_API = ""
+    GOFILE_FOLDER_ID = ""
     GDRIVE_ID = ""
     GD_DESP = "Uploaded with WZ Bot"
     AUTHOR_NAME = "WZML-X"

--- a/bot/core/handlers.py
+++ b/bot/core/handlers.py
@@ -208,6 +208,13 @@ def add_handlers():
     )
     TgClient.bot.add_handler(
         MessageHandler(
+            ddl,
+            filters=command(BotCommands.DDLCommand, case_sensitive=True)
+            & CustomFilters.authorized,
+        )
+    )
+    TgClient.bot.add_handler(
+        MessageHandler(
             get_rss_menu,
             filters=command(BotCommands.RssCommand, case_sensitive=True)
             & CustomFilters.authorized,

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -104,6 +104,7 @@ class TaskConfig:
         self.is_nzb = False
         self.is_jd = False
         self.is_clone = False
+        self.is_ddl = False
         self.is_gdrive = False
         self.is_rclone = False
         self.is_ytdlp = False
@@ -157,7 +158,7 @@ class TaskConfig:
             )
         )
 
-        out_mode = f"#{'Leech' if self.is_leech else 'Clone' if self.is_clone else 'RClone' if self.up_dest.startswith('mrcc:') or is_rclone_path(self.up_dest) else 'GDrive' if self.up_dest.startswith(('mtp:', 'tp:', 'sa:')) or is_gdrive_id(self.up_dest) else 'UpHosters'}"
+        out_mode = f"#{'Leech' if self.is_leech else 'DDLUpload' if self.is_ddl else 'Clone' if self.is_clone else 'RClone' if self.up_dest.startswith('mrcc:') or is_rclone_path(self.up_dest) else 'GDrive' if self.up_dest.startswith(('mtp:', 'tp:', 'sa:')) or is_gdrive_id(self.up_dest) else 'UpHosters'}"
         out_mode += " (Zip)" if self.compress else " (Unzip)" if self.extract else ""
 
         self.is_rclone = is_rclone_path(self.link)

--- a/bot/helper/ext_utils/links_utils.py
+++ b/bot/helper/ext_utils/links_utils.py
@@ -3,8 +3,11 @@ from base64 import urlsafe_b64decode, urlsafe_b64encode
 
 
 def is_magnet(url: str):
-    return bool(re_match(r"^magnet:\?.*xt=urn:(btih|btmh):([a-zA-Z0-9]{32,40}|[a-z2-7]{32}).*", url))
-
+    return bool(
+        re_match(
+            r"^magnet:\?.*xt=urn:(btih|btmh):([a-zA-Z0-9]{32,40}|[a-z2-7]{32}).*", url
+        )
+    )
 
 
 def is_url(url: str):

--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -55,6 +55,7 @@ class EngineStatus:
         self.STATUS_JD = "JDownloader v2"
         self.STATUS_YT = "Youtube-Api"
         self.STATUS_METADATA = "Metadata"
+        self.STATUS_DDL = "DDL"
 
 
 STATUSES = {

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -41,8 +41,10 @@ from ..ext_utils.files_utils import (
 from ..ext_utils.links_utils import is_gdrive_id
 from ..ext_utils.status_utils import get_readable_file_size, get_readable_time
 from ..ext_utils.task_manager import check_running_tasks, start_from_queued
+from ..mirror_leech_utils.ddl_utils.gofile_utils.upload import GoFileUpload
 from ..mirror_leech_utils.gdrive_utils.upload import GoogleDriveUpload
 from ..mirror_leech_utils.rclone_utils.transfer import RcloneTransferHelper
+from ..mirror_leech_utils.status_utils.ddl_status import DDLStatus
 from ..mirror_leech_utils.status_utils.gdrive_status import (
     GoogleDriveStatus,
 )
@@ -351,6 +353,16 @@ class TaskListener(TaskConfig):
                 tg.upload(),
             )
             del tg
+        elif self.is_ddl:
+            LOGGER.info(f"DDL Upload Name: {self.name}")
+            ddl = GoFileUpload(self, up_path)
+            async with task_dict_lock:
+                task_dict[self.mid] = DDLStatus(self, ddl, gid, "up")
+            await gather(
+                update_status_message(self.message.chat.id),
+                ddl.upload(),
+            )
+            del ddl
         elif is_gdrive_id(self.up_dest):
             LOGGER.info(f"Gdrive Upload Name: {self.name}")
             drive = GoogleDriveUpload(self, up_path)

--- a/bot/helper/mirror_leech_utils/ddl_utils/gofile_utils/upload.py
+++ b/bot/helper/mirror_leech_utils/ddl_utils/gofile_utils/upload.py
@@ -1,0 +1,385 @@
+from io import BufferedReader
+from json import JSONDecodeError
+from logging import getLogger
+from os import path as ospath
+from os import walk as oswalk
+from pathlib import Path
+from random import choice
+
+from aiofiles.os import path as aiopath
+from aiofiles.os import rename as aiorename
+from aiohttp import ClientSession
+from aiohttp.client_exceptions import ContentTypeError
+from tenacity import (
+    RetryError,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from bot.core.config_manager import Config
+from bot.helper.ext_utils.bot_utils import SetInterval, sync_to_async
+
+LOGGER = getLogger(__name__)
+
+
+class ProgressFileReader(BufferedReader):
+    def __init__(self, filename, read_callback=None):
+        super().__init__(open(filename, "rb"))
+        self.__read_callback = read_callback
+        self.length = Path(filename).stat().st_size
+
+    def read(self, size=None):
+        size = size or (self.length - self.tell())
+        if self.__read_callback:
+            self.__read_callback(self.tell())
+        return super().read(size)
+
+
+class GoFileUpload:
+    def __init__(self, listener, path):
+        self.listener = listener
+        self._updater = None
+        self._path = path
+        self._is_errored = False
+        self.api_url = "https://api.gofile.io/"
+        self.__processed_bytes = 0
+        self.last_uploaded = 0
+        self.total_time = 0
+        self.total_files = 0
+        self.total_folders = 0
+        self.is_uploading = True
+        self.update_interval = 3
+
+        # Get user-specific token or fall back to global config
+        from bot import user_data
+
+        user_dict = user_data.get(self.listener.user_id, {})
+        self.token = user_dict.get("GOFILE_TOKEN") or Config.GOFILE_API
+        self.folder_id = (
+            user_dict.get("GOFILE_FOLDER_ID") or Config.GOFILE_FOLDER_ID or ""
+        )
+
+    @property
+    def speed(self):
+        try:
+            return self.__processed_bytes / self.total_time
+        except Exception:
+            return 0
+
+    @property
+    def processed_bytes(self):
+        return self.__processed_bytes
+
+    def __progress_callback(self, current):
+        chunk_size = current - self.last_uploaded
+        self.last_uploaded = current
+        self.__processed_bytes += chunk_size
+
+    async def progress(self):
+        self.total_time += self.update_interval
+
+    @staticmethod
+    async def is_goapi(token):
+        if token is None:
+            return False
+
+        async with (
+            ClientSession() as session,
+            session.get(f"https://api.gofile.io/accounts/getid?token={token}") as resp,
+        ):
+            res = await resp.json()
+
+            if res["status"] == "ok":
+                acc_id = res["data"]["id"]
+                async with session.get(
+                    f"https://api.gofile.io/accounts/{acc_id}?token={token}"
+                ) as resp:
+                    return (await resp.json())["status"] == "ok"
+        return False
+
+    async def __resp_handler(self, response):
+        if (api_resp := response.get("status", "")) == "ok":
+            return response["data"]
+        raise Exception(
+            api_resp.split("-")[1]
+            if "error-" in api_resp
+            else "Response Status is not ok and Reason is Unknown"
+        )
+
+    async def __getServer(self):
+        async with ClientSession() as session:
+            async with session.get(f"{self.api_url}servers") as resp:
+                return await self.__resp_handler(await resp.json())
+
+    async def __getAccount(self, check_account=False):
+        if self.token is None:
+            raise Exception("GoFile API token not found!")
+
+        async with (
+            ClientSession() as session,
+            session.get(f"{self.api_url}accounts/getid?token={self.token}") as resp,
+        ):
+            res = await resp.json()
+            if res["status"] == "ok":
+                acc_id = res["data"]["id"]
+                async with session.get(
+                    f"{self.api_url}accounts/{acc_id}?token={self.token}"
+                ) as resp2:
+                    res2 = await resp2.json()
+                    return (
+                        res2["status"] == "ok"
+                        if check_account
+                        else await self.__resp_handler(res2)
+                    )
+        return None
+
+    async def __setOptions(self, contentId, option, value):
+        if self.token is None:
+            raise Exception("GoFile API token not found!")
+
+        if option not in [
+            "name",
+            "description",
+            "tags",
+            "public",
+            "expiry",
+            "password",
+        ]:
+            raise Exception(f"Invalid GoFile Option Specified: {option}")
+
+        async with (
+            ClientSession() as session,
+            session.put(
+                url=f"{self.api_url}contents/{contentId}/update",
+                data={
+                    "token": self.token,
+                    "attribute": option,
+                    "attributeValue": value,
+                },
+            ) as resp,
+        ):
+            return await self.__resp_handler(await resp.json())
+
+    @retry(
+        wait=wait_exponential(multiplier=2, min=4, max=8),
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_type(Exception),
+    )
+    async def upload_aiohttp(self, url, file_path, req_file, data):
+        with ProgressFileReader(
+            filename=file_path, read_callback=self.__progress_callback
+        ) as file:
+            data[req_file] = file
+            async with ClientSession() as session:
+                async with session.post(url, data=data) as resp:
+                    if resp.status == 200:
+                        try:
+                            return await resp.json()
+                        except ContentTypeError:
+                            return {
+                                "status": "ok",
+                                "data": {"downloadPage": "Uploaded"},
+                            }
+                        except JSONDecodeError:
+                            return {
+                                "status": "ok",
+                                "data": {"downloadPage": "Uploaded"},
+                            }
+                    else:
+                        raise Exception(f"HTTP {resp.status}: {await resp.text()}")
+        return None
+
+    async def create_folder(self, parentFolderId, folderName):
+        if self.token is None:
+            raise Exception("GoFile API token not found!")
+
+        async with (
+            ClientSession() as session,
+            session.post(
+                url=f"{self.api_url}contents/createFolder",
+                data={
+                    "token": self.token,
+                    "parentFolderId": parentFolderId,
+                    "folderName": folderName,
+                },
+            ) as resp,
+        ):
+            return await self.__resp_handler(await resp.json())
+
+    async def upload_file(
+        self,
+        path: str,
+        folderId: str = "",
+        description: str = "",
+        password: str = "",
+        tags: str = "",
+        expire: str = "",
+    ):
+        if password and len(password) < 4:
+            raise ValueError("Password Length must be greater than 4")
+
+        server = choice((await self.__getServer())["servers"])["name"]
+        req_dict = {}
+
+        if self.token:
+            req_dict["token"] = self.token
+        if folderId:
+            req_dict["folderId"] = folderId
+        if description:
+            req_dict["description"] = description
+        if password:
+            req_dict["password"] = password
+        if tags:
+            req_dict["tags"] = tags
+        if expire:
+            req_dict["expire"] = expire
+
+        if self.listener.is_cancelled:
+            return None
+
+        # Replace spaces with dots in filename
+        new_path = ospath.join(
+            ospath.dirname(path), ospath.basename(path).replace(" ", ".")
+        )
+        await aiorename(path, new_path)
+
+        upload_file = await self.upload_aiohttp(
+            f"https://{server}.gofile.io/contents/uploadfile",
+            new_path,
+            "file",
+            req_dict,
+        )
+        return await self.__resp_handler(upload_file)
+
+    async def _upload_dir(self, input_directory, parent_folder_id=None):
+        if parent_folder_id is None:
+            # Use user's folder_id if specified, otherwise create in root
+            if self.folder_id:
+                # Upload to user's specified folder
+                parent_folder_id = self.folder_id
+                main_folder_code = self.folder_id
+            else:
+                # Create main folder in root
+                account_data = await self.__getAccount()
+                folder_data = await self.create_folder(
+                    account_data["rootFolder"], ospath.basename(input_directory)
+                )
+                await self.__setOptions(
+                    contentId=folder_data["folderId"], option="public", value="true"
+                )
+                parent_folder_id = folder_data["folderId"]
+                main_folder_code = folder_data["code"]
+        else:
+            main_folder_code = None
+
+        folder_ids = {".": parent_folder_id}
+
+        for root, _dirs, files in await sync_to_async(oswalk, input_directory):
+            if self.listener.is_cancelled:
+                break
+
+            rel_path = ospath.relpath(root, input_directory)
+            current_folder_id = folder_ids.get(
+                ospath.dirname(rel_path), parent_folder_id
+            )
+
+            # Create folders for current directory
+            if rel_path != ".":
+                folder_name = ospath.basename(rel_path)
+                curr_folder_data = await self.create_folder(
+                    current_folder_id, folder_name
+                )
+                await self.__setOptions(
+                    contentId=curr_folder_data["folderId"],
+                    option="public",
+                    value="true",
+                )
+                folder_ids[rel_path] = curr_folder_data["folderId"]
+                current_folder_id = curr_folder_data["folderId"]
+                self.total_folders += 1
+
+            # Upload files in current directory
+            for file in files:
+                if self.listener.is_cancelled:
+                    break
+
+                file_path = ospath.join(root, file)
+                await self.upload_file(file_path, current_folder_id)
+                self.total_files += 1
+
+        return main_folder_code
+
+    async def upload(self):
+        try:
+            LOGGER.info(f"GoFile Uploading: {self._path}")
+            self._updater = SetInterval(self.update_interval, self.progress)
+
+            if not self.token:
+                raise ValueError(
+                    "GoFile API token not configured! Please set your GoFile token in user settings or configure a global token."
+                )
+
+            # Run the async process directly
+            await self._upload_process()
+
+        except Exception as err:
+            if isinstance(err, RetryError):
+                LOGGER.info(f"Total Attempts: {err.last_attempt.attempt_number}")
+                err = err.last_attempt.exception()
+            err = str(err).replace(">", "").replace("<", "")
+            LOGGER.error(err)
+            await self.listener.on_upload_error(err)
+            self._is_errored = True
+        finally:
+            if self._updater:
+                self._updater.cancel()
+            if (
+                self.listener.is_cancelled and not self._is_errored
+            ) or self._is_errored:
+                return
+
+    async def _upload_process(self):
+        if not await self.is_goapi(self.token):
+            raise Exception("Invalid GoFile API Key, please check your token!")
+
+        if await aiopath.isfile(self._path):
+            # Single file upload
+            file_result = await self.upload_file(
+                path=self._path, folderId=self.folder_id
+            )
+            if file_result and file_result.get("downloadPage"):
+                link = file_result["downloadPage"]
+                mime_type = "File"
+                self.total_files = 1
+            else:
+                raise ValueError("Failed to upload file to GoFile")
+        elif await aiopath.isdir(self._path):
+            # Directory upload
+            folder_code = await self._upload_dir(self._path)
+            if folder_code:
+                link = f"https://gofile.io/d/{folder_code}"
+                mime_type = "Folder"
+            else:
+                raise ValueError("Failed to upload folder to GoFile")
+        else:
+            raise ValueError("Invalid file path!")
+
+        if self.listener.is_cancelled:
+            return
+
+        LOGGER.info(f"Uploaded To GoFile: {self.listener.name}")
+        await self.listener.on_upload_complete(
+            link,
+            self.total_files,
+            self.total_folders,
+            mime_type,
+            dir_id="",
+        )
+
+    async def cancel_task(self):
+        self.listener.is_cancelled = True
+        if self.is_uploading:
+            LOGGER.info(f"Cancelling GoFile Upload: {self.listener.name}")
+            await self.listener.on_upload_error("GoFile upload has been cancelled!")

--- a/bot/helper/mirror_leech_utils/status_utils/ddl_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/ddl_status.py
@@ -1,0 +1,55 @@
+from ....helper.ext_utils.status_utils import (
+    MirrorStatus,
+    EngineStatus,
+    get_readable_file_size,
+    get_readable_time,
+)
+
+
+class DDLStatus:
+    def __init__(self, listener, obj, gid, status):
+        self.listener = listener
+        self._obj = obj
+        self._size = self.listener.size
+        self._gid = gid
+        self._status = status
+        self.engine = EngineStatus().STATUS_DDL
+
+    def processed_bytes(self):
+        return get_readable_file_size(self._obj.processed_bytes)
+
+    def size(self):
+        return get_readable_file_size(self._size)
+
+    def status(self):
+        if self._status == "up":
+            return MirrorStatus.STATUS_UPLOAD
+        return MirrorStatus.STATUS_DOWNLOAD
+
+    def name(self):
+        return self.listener.name
+
+    def gid(self) -> str:
+        return self._gid
+
+    def progress_raw(self):
+        try:
+            return self._obj.processed_bytes / self._size * 100
+        except ZeroDivisionError:
+            return 0
+
+    def progress(self):
+        return f"{round(self.progress_raw(), 2)}%"
+
+    def speed(self):
+        return f"{get_readable_file_size(self._obj.speed)}/s"
+
+    def eta(self):
+        try:
+            seconds = (self._size - self._obj.processed_bytes) / self._obj.speed
+            return get_readable_time(seconds)
+        except Exception:
+            return "-"
+
+    def task(self):
+        return self._obj

--- a/bot/helper/telegram_helper/bot_commands.py
+++ b/bot/helper/telegram_helper/bot_commands.py
@@ -11,6 +11,7 @@ class BotCommands:
         "QbMirror": ["qbmirror", "qm"],
         "JdMirror": ["jdmirror", "jm"],
         "Ytdl": ["ytdl", "y"],
+        "DDL": "ddl",
         "NzbMirror": ["nzbmirror", "nm"],
         "Leech": ["leech", "l"],
         "QbLeech": ["qbleech", "ql"],

--- a/bot/modules/__init__.py
+++ b/bot/modules/__init__.py
@@ -11,6 +11,7 @@ from .gd_search import gdrive_search, select_type
 from .help import arg_usage, bot_help
 from .mediainfo import mediainfo
 from .broadcast import broadcast
+from .ddl import ddl
 from .mirror_leech import (
     mirror,
     leech,
@@ -62,6 +63,7 @@ __all__ = [
     "gdrive_search",
     "select_type",
     "arg_usage",
+    "ddl",
     "mirror",
     "leech",
     "qb_leech",

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -74,7 +74,6 @@ DEFAULT_VALUES = {
 }
 
 
-
 async def get_buttons(key=None, edit_type=None, edit_mode=False):
     buttons = ButtonMaker()
     if key is None:

--- a/bot/modules/ddl.py
+++ b/bot/modules/ddl.py
@@ -1,0 +1,6 @@
+from bot import bot_loop
+from bot.modules.mirror_leech import Mirror
+
+
+async def ddl(client, message):
+    bot_loop.create_task(Mirror(client, message, is_ddl=True).new_event())

--- a/bot/modules/imdb.py
+++ b/bot/modules/imdb.py
@@ -20,6 +20,7 @@ from ..helper.telegram_helper.message_utils import (
 # Monkeypatch IMDbHTTPAccessSystem._retrieve to use cloudscraper
 scraper = cloudscraper.create_scraper()
 
+
 def _retrieve_patched(self, url, size=-1, _noCookies=False):
     try:
         response = scraper.get(url)
@@ -27,6 +28,7 @@ def _retrieve_patched(self, url, size=-1, _noCookies=False):
         return response.text
     except Exception as e:
         raise
+
 
 IMDbHTTPAccessSystem._retrieve = _retrieve_patched
 

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -60,6 +60,7 @@ class Mirror(TaskListener):
         is_leech=False,
         is_jd=False,
         is_nzb=False,
+        is_ddl=False,
         same_dir=None,
         bulk=None,
         multi_tag=None,
@@ -80,6 +81,7 @@ class Mirror(TaskListener):
         self.is_leech = is_leech
         self.is_jd = is_jd
         self.is_nzb = is_nzb
+        self.is_ddl = is_ddl
 
     async def new_event(self):
         text = self.message.text.split("\n")
@@ -304,6 +306,7 @@ class Mirror(TaskListener):
                 self.is_leech,
                 self.is_jd,
                 self.is_nzb,
+                self.is_ddl,
                 self.same_dir,
                 self.bulk,
                 self.multi_tag,

--- a/bot/modules/users_settings.py
+++ b/bot/modules/users_settings.py
@@ -43,6 +43,7 @@ leech_options = [
     "LEECH_CAPTION",
     "THUMBNAIL_LAYOUT",
 ]
+ddl_options = ["GOFILE_TOKEN", "GOFILE_FOLDER_ID"]
 rclone_options = ["RCLONE_CONFIG", "RCLONE_PATH", "RCLONE_FLAGS"]
 gdrive_options = ["TOKEN_PICKLE", "GDRIVE_ID", "INDEX_URL"]
 ffset_options = [
@@ -255,6 +256,16 @@ Here I will explain how to use mltb.* which is reference to files you want to wo
         "User's YT-DLP Cookie File to authenticate access to websites and youtube.",
         "<i>Send your cookie file (e.g., cookies.txt or abc.txt).</i> \n┖ <b>Time Left :</b> <code>60 sec</code>",
     ),
+    "GOFILE_TOKEN": (
+        "String",
+        "Gofile API Token",
+        "<i>Send your Gofile API Token.</i> \n┖ <b>Time Left :</b> <code>60 sec</code>",
+    ),
+    "GOFILE_FOLDER_ID": (
+        "String",
+        "Gofile Folder ID",
+        "<i>Send your Gofile Folder ID.</i> \n┖ <b>Time Left :</b> <code>60 sec</code>",
+    ),
 }
 
 
@@ -272,6 +283,7 @@ async def get_user_settings(from_user, stype="main"):
         )
         buttons.data_button("Mirror Settings", f"userset {user_id} mirror")
         buttons.data_button("Leech Settings", f"userset {user_id} leech")
+        buttons.data_button("DDL Settings", f"userset {user_id} ddl")
         buttons.data_button("FF Media Settings", f"userset {user_id} ffset")
         buttons.data_button(
             "Mics Settings", f"userset {user_id} advanced", position="l_body"
@@ -493,6 +505,46 @@ async def get_user_settings(from_user, stype="main"):
 ┠ Mixed Leech → <b>{hybrid_leech}</b>
 ┖ Thumbnail Layout → <b>{thumb_layout}</b>
 """
+
+    elif stype == "ddl":
+        buttons.data_button("Gofile Tools", f"userset {user_id} gofile")
+        buttons.data_button("Back", f"userset {user_id} back", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        btns = buttons.build_menu(1)
+
+        text = f"""⌬ <b>DDL Settings :</b>
+┟ <b>Name</b> → {user_name}
+┃
+┖ <b>Current</b> → Gofile"""
+
+    elif stype == "gofile":
+        buttons.data_button("Gofile Token", f"userset {user_id} menu GOFILE_TOKEN")
+        buttons.data_button(
+            "Gofile Folder ID", f"userset {user_id} menu GOFILE_FOLDER_ID"
+        )
+        buttons.data_button("Back", f"userset {user_id} back ddl", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        btns = buttons.build_menu(1)
+
+        if user_dict.get("GOFILE_TOKEN", False):
+            gftoken = user_dict["GOFILE_TOKEN"]
+        elif Config.GOFILE_API:
+            gftoken = Config.GOFILE_API
+        else:
+            gftoken = "None"
+
+        if user_dict.get("GOFILE_FOLDER_ID", False):
+            gffolder = user_dict["GOFILE_FOLDER_ID"]
+        elif Config.GOFILE_FOLDER_ID:
+            gffolder = Config.GOFILE_FOLDER_ID
+        else:
+            gffolder = "None"
+
+        text = f"""⌬ <b>Gofile Settings :</b>
+┟ <b>Name</b> → {user_name}
+┃
+┠ <b>Gofile Token</b> → <code>{gftoken}</code>
+┖ <b>Gofile Folder ID</b> → <code>{gffolder}</code>"""
 
     elif stype == "rclone":
         buttons.data_button("Rclone Config", f"userset {user_id} menu RCLONE_CONFIG")
@@ -1135,6 +1187,8 @@ async def edit_user_settings(client, query):
         "general",
         "mirror",
         "leech",
+        "ddl",
+        "gofile",
         "ffset",
         "advanced",
         "gdrive",


### PR DESCRIPTION
## Summary by Sourcery

Add direct download (DDL) support via Gofile as a new upload destination with corresponding user settings and command entry point.

New Features:
- Introduce a DDL workflow that uploads completed downloads to Gofile instead of cloud drives or hosters.
- Add user-configurable Gofile API token and folder ID settings, with per-user overrides and global fallbacks.
- Expose a new /ddl command and settings menu sections to trigger and manage DDL uploads via the bot.

Enhancements:
- Extend status tracking and mode labelling to cover DDL uploads, including progress, speed, and ETA reporting.