### PR TITLE
feat: Add Support for Uphoster multi destinations

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -303,20 +303,25 @@ class TaskConfig:
 
             if self.is_uphoster and not self.up_dest:
                 uphoster_service = self.user_dict.get("UPHOSTER_SERVICE", "gofile")
-                if uphoster_service == "gofile":
-                    if not (self.user_dict.get("GOFILE_TOKEN") or Config.GOFILE_API):
-                        raise ValueError("No Uphoster Destination Found!")
-                elif uphoster_service == "buzzheavier":
-                    if not (
-                        self.user_dict.get("BUZZHEAVIER_TOKEN")
-                        or Config.BUZZHEAVIER_API
-                    ):
-                        raise ValueError("No Uphoster Destination Found!")
-                elif uphoster_service == "pixeldrain":
-                    if not (
-                        self.user_dict.get("PIXELDRAIN_KEY") or Config.PIXELDRAIN_KEY
-                    ):
-                        raise ValueError("No Uphoster Destination Found!")
+                services = uphoster_service.split(",")
+                for service in services:
+                    if service == "gofile":
+                        if not (
+                            self.user_dict.get("GOFILE_TOKEN") or Config.GOFILE_API
+                        ):
+                            raise ValueError("No Gofile Token Found!")
+                    elif service == "buzzheavier":
+                        if not (
+                            self.user_dict.get("BUZZHEAVIER_TOKEN")
+                            or Config.BUZZHEAVIER_API
+                        ):
+                            raise ValueError("No BuzzHeavier Token Found!")
+                    elif service == "pixeldrain":
+                        if not (
+                            self.user_dict.get("PIXELDRAIN_KEY")
+                            or Config.PIXELDRAIN_KEY
+                        ):
+                            raise ValueError("No PixelDrain Key Found!")
                 self.up_dest = "Uphoster"
 
             if not self.up_dest:

--- a/bot/helper/mirror_leech_utils/uphoster_utils/multi_upload.py
+++ b/bot/helper/mirror_leech_utils/uphoster_utils/multi_upload.py
@@ -1,0 +1,110 @@
+from asyncio import gather
+from logging import getLogger
+
+from bot.helper.mirror_leech_utils.uphoster_utils.gofile_utils.upload import (
+    GoFileUpload,
+)
+from bot.helper.mirror_leech_utils.uphoster_utils.buzzheavier_utils.upload import (
+    BuzzHeavierUpload,
+)
+from bot.helper.mirror_leech_utils.uphoster_utils.pixeldrain_utils.upload import (
+    PixelDrainUpload,
+)
+
+LOGGER = getLogger(__name__)
+
+
+class MultiUphosterUpload:
+    def __init__(self, listener, path, services):
+        self.listener = listener
+        self.path = path
+        self.services = services
+        self.uploaders = []
+        self._processed_bytes = 0
+        self._speed = 0
+        self.is_cancelled = False
+        self.results = {}
+        self.failed = []
+
+        for service in services:
+            if service == "gofile":
+                self.uploaders.append(GoFileUpload(ProxyListener(self, "gofile"), path))
+            elif service == "buzzheavier":
+                self.uploaders.append(
+                    BuzzHeavierUpload(ProxyListener(self, "buzzheavier"), path)
+                )
+            elif service == "pixeldrain":
+                self.uploaders.append(
+                    PixelDrainUpload(ProxyListener(self, "pixeldrain"), path)
+                )
+
+    @property
+    def speed(self):
+        return sum(u.speed for u in self.uploaders)
+
+    @property
+    def processed_bytes(self):
+        if not self.uploaders:
+            return 0
+        return sum(u.processed_bytes for u in self.uploaders) / len(self.uploaders)
+
+    async def upload(self):
+        tasks = [u.upload() for u in self.uploaders]
+        await gather(*tasks)
+
+    async def cancel_task(self):
+        self.is_cancelled = True
+        tasks = [u.cancel_task() for u in self.uploaders]
+        await gather(*tasks)
+
+    async def on_upload_complete(
+        self, service, link, files, folders, mime_type, dir_id
+    ):
+        self.results[service] = {
+            "link": link,
+            "files": files,
+            "folders": folders,
+            "mime_type": mime_type,
+            "dir_id": dir_id,
+        }
+        await self._check_completion()
+
+    async def on_upload_error(self, service, error):
+        LOGGER.error(f"Upload failed for {service}: {error}")
+        self.failed.append(service)
+        self.results[service] = {"error": error}
+        await self._check_completion()
+
+    async def _check_completion(self):
+        if len(self.results) == len(self.uploaders):
+            if len(self.failed) == len(self.uploaders):
+                await self.listener.on_upload_error("All uploads failed.")
+            else:
+                successful_result = next(
+                    v for k, v in self.results.items() if "error" not in v
+                )
+                await self.listener.on_upload_complete(
+                    self.results,
+                    successful_result["files"],
+                    successful_result["folders"],
+                    successful_result["mime_type"],
+                    successful_result["dir_id"],
+                )
+
+
+class ProxyListener:
+    def __init__(self, multi_uploader, service):
+        self.multi_uploader = multi_uploader
+        self.service = service
+        self.is_cancelled = False
+
+    def __getattr__(self, name):
+        return getattr(self.multi_uploader.listener, name)
+
+    async def on_upload_complete(self, link, files, folders, mime_type, dir_id=""):
+        await self.multi_uploader.on_upload_complete(
+            self.service, link, files, folders, mime_type, dir_id
+        )
+
+    async def on_upload_error(self, error):
+        await self.multi_uploader.on_upload_error(self.service, error)


### PR DESCRIPTION
## Summary by Sourcery

Add multi-destination support for Uphoster uploads and update user settings and upload flows accordingly.

New Features:
- Allow users to select multiple Uphoster destinations (Gofile, BuzzHeavier, PixelDrain) in their settings.
- Introduce a MultiUphosterUpload helper that uploads to all selected Uphoster services concurrently and aggregates results.
- Display individual cloud links and per-service error messages when using multiple Uphoster destinations.

Enhancements:
- Update Uphoster settings UI to show all selected destinations and provide a dedicated destination selection menu.
- Improve Uphoster destination validation with clearer, per-service token/key error messages before starting uploads.