### PR TITLE
Fix: Correct argument passing in init_bulk and run_multi

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -594,18 +594,29 @@ class TaskConfig:
             nextmsg.sender_chat = self.user
         if intervals["stopAll"]:
             return
-        await obj(
-            self.client,
-            nextmsg,
-            self.is_qbit,
-            self.is_leech,
-            self.is_jd,
-            self.is_nzb,
-            self.same_dir,
-            self.bulk,
-            self.multi_tag,
-            self.options,
-        ).new_event()
+        if obj.__name__ == "Mirror":
+            await obj(
+                client=self.client,
+                message=nextmsg,
+                is_qbit=self.is_qbit,
+                is_leech=self.is_leech,
+                is_jd=self.is_jd,
+                is_nzb=self.is_nzb,
+                is_uphoster=self.is_uphoster,
+                same_dir=self.same_dir,
+                bulk=self.bulk,
+                multi_tag=self.multi_tag,
+                options=self.options,
+            ).new_event()
+        else:
+            await obj(
+                client=self.client,
+                message=nextmsg,
+                same_dir=self.same_dir,
+                bulk=self.bulk,
+                multi_tag=self.multi_tag,
+                options=self.options,
+            ).new_event()
 
     async def init_bulk(self, input_list, bulk_start, bulk_end, obj):
         if Config.DISABLE_BULK:
@@ -636,18 +647,29 @@ class TaskConfig:
                 nextmsg.from_user = self.user
             else:
                 nextmsg.sender_chat = self.user
-            await obj(
-                self.client,
-                nextmsg,
-                self.is_qbit,
-                self.is_leech,
-                self.is_jd,
-                self.is_nzb,
-                self.same_dir,
-                self.bulk,
-                self.multi_tag,
-                self.options,
-            ).new_event()
+            if obj.__name__ == "Mirror":
+                await obj(
+                    client=self.client,
+                    message=nextmsg,
+                    is_qbit=self.is_qbit,
+                    is_leech=self.is_leech,
+                    is_jd=self.is_jd,
+                    is_nzb=self.is_nzb,
+                    is_uphoster=self.is_uphoster,
+                    same_dir=self.same_dir,
+                    bulk=self.bulk,
+                    multi_tag=self.multi_tag,
+                    options=self.options,
+                ).new_event()
+            else:
+                await obj(
+                    client=self.client,
+                    message=nextmsg,
+                    same_dir=self.same_dir,
+                    bulk=self.bulk,
+                    multi_tag=self.multi_tag,
+                    options=self.options,
+                ).new_event()
         except Exception:
             await send_message(
                 self.message,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct parameter mapping when invoking handler objects from run_multi and init_bulk, ensuring Mirror receives all required flags including is_uphoster and other handlers receive only the applicable arguments.