### PR TITLE
Fix: Correct argument passing in init_bulk and run_multi

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -594,17 +594,19 @@ class TaskConfig:
             nextmsg.sender_chat = self.user
         if intervals["stopAll"]:
             return
+
         await obj(
-            self.client,
-            nextmsg,
-            self.is_qbit,
-            self.is_leech,
-            self.is_jd,
-            self.is_nzb,
-            self.same_dir,
-            self.bulk,
-            self.multi_tag,
-            self.options,
+            client=self.client,
+            message=nextmsg,
+            is_qbit=self.is_qbit,
+            is_leech=self.is_leech,
+            is_jd=self.is_jd,
+            is_nzb=self.is_nzb,
+            is_uphoster=self.is_uphoster,
+            same_dir=self.same_dir,
+            bulk=self.bulk,
+            multi_tag=self.multi_tag,
+            options=self.options,
         ).new_event()
 
     async def init_bulk(self, input_list, bulk_start, bulk_end, obj):
@@ -636,17 +638,19 @@ class TaskConfig:
                 nextmsg.from_user = self.user
             else:
                 nextmsg.sender_chat = self.user
+
             await obj(
-                self.client,
-                nextmsg,
-                self.is_qbit,
-                self.is_leech,
-                self.is_jd,
-                self.is_nzb,
-                self.same_dir,
-                self.bulk,
-                self.multi_tag,
-                self.options,
+                client=self.client,
+                message=nextmsg,
+                is_qbit=self.is_qbit,
+                is_leech=self.is_leech,
+                is_jd=self.is_jd,
+                is_nzb=self.is_nzb,
+                is_uphoster=self.is_uphoster,
+                same_dir=self.same_dir,
+                bulk=self.bulk,
+                multi_tag=self.multi_tag,
+                options=self.options,
             ).new_event()
         except Exception:
             await send_message(

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -65,6 +65,7 @@ class Mirror(TaskListener):
         bulk=None,
         multi_tag=None,
         options="",
+        **kwargs,
     ):
         if same_dir is None:
             same_dir = {}

--- a/bot/modules/uphoster.py
+++ b/bot/modules/uphoster.py
@@ -60,6 +60,7 @@ class Uphoster(TaskListener):
         bulk=None,
         multi_tag=None,
         options="",
+        **kwargs,
     ):
         if same_dir is None:
             same_dir = {}


### PR DESCRIPTION
## Summary by Sourcery

Ensure bulk and multi-run helpers pass the correct keyword arguments to downstream handlers and make handlers tolerant of additional parameters.

Bug Fixes:
- Correct argument passing in run_multi and init_bulk to use keyword arguments and include the is_uphoster flag so downstream handlers receive the expected parameters.

Enhancements:
- Allow mirror_leech and uphoster handler constructors to accept and ignore additional keyword arguments for more flexible invocation.