### PR TITLE
Fix: Ensure bulk commands pass arguments correctly to task constructors

### DIFF
--- a/bot/modules/clone.py
+++ b/bot/modules/clone.py
@@ -48,14 +48,10 @@ class Clone(TaskListener):
         self,
         client,
         message,
-        _=None,
-        __=None,
-        ___=None,
-        ____=None,
-        _____=None,
         bulk=None,
         multi_tag=None,
         options="",
+        **kwargs,
     ):
         if bulk is None:
             bulk = []

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -262,14 +262,12 @@ class YtDlp(TaskListener):
         self,
         client,
         message,
-        _=None,
         is_leech=False,
-        __=None,
-        ___=None,
         same_dir=None,
         bulk=None,
         multi_tag=None,
         options="",
+        **kwargs,
     ):
         if same_dir is None:
             same_dir = {}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix task constructors for clone and ytdlp modules so bulk-invoked commands can pass additional arguments without breaking.