### PR TITLE
fix: minor issues

### DIFF
--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -1,4 +1,4 @@
-from asyncio import create_subprocess_exec, create_subprocess_shell
+from asyncio import create_subprocess_exec, create_subprocess_shell, sleep
 from importlib import import_module
 from os import environ, getenv, path as ospath
 
@@ -32,6 +32,7 @@ from .torrent_manager import TorrentManager
 
 
 async def update_qb_options():
+    LOGGER.info("Get qBittorrent options from server")
     if not qbit_options:
         if not TorrentManager.qbittorrent:
             LOGGER.warning(
@@ -53,6 +54,7 @@ async def update_qb_options():
 
 
 async def update_aria2_options():
+    LOGGER.info("Get aria2 options from server")
     if not aria2_options:
         op = await TorrentManager.aria2.getGlobalOption()
         aria2_options.update(op)
@@ -62,11 +64,15 @@ async def update_aria2_options():
 
 async def update_nzb_options():
     if Config.USENET_SERVERS:
-        try:
-            no = (await sabnzbd_client.get_config())["config"]["misc"]
-            nzb_options.update(no)
-        except (APIResponseError, Exception) as e:
-            LOGGER.error(f"Error in NZB Options: {e}")
+        LOGGER.info("Get SABnzbd options from server")
+        while True:
+            try:
+                no = (await sabnzbd_client.get_config())["config"]["misc"]
+                nzb_options.update(no)
+            except Exception:
+                await sleep(0.5)
+                continue
+            break
 
 
 async def load_settings():

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -195,7 +195,7 @@ def arg_parser(items, arg_base):
             else:
                 sub_list = []
                 for j in range(i + 1, total):
-                    if items[j] in arg_base:
+                    if items[j] in arg_base and part != "-c" != items[j]:
                         if part in bool_arg_set and not sub_list:
                             arg_base[part] = True
                             break

--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -214,8 +214,6 @@ async def take_ss(video_file, ss_nb) -> bool:
                 "1",
                 "-frames:v",
                 "1",
-                "-threads",
-                f"{max(1, cpu_no // 2)}",
                 output,
             ]
             cap_time += interval
@@ -254,8 +252,6 @@ async def get_audio_thumbnail(audio_file):
         "-an",
         "-vcodec",
         "copy",
-        "-threads",
-        f"{max(1, cpu_no // 2)}",
         output,
     ]
     try:
@@ -296,8 +292,6 @@ async def get_video_thumbnail(video_file, duration):
         "-q:v",
         "5",
         "-vframes",
-        "1",
-        "-threads",
         "1",
         output,
     ]
@@ -349,8 +343,6 @@ async def get_multiple_frames_thumbnail(video_file, layout, keep_screenshots):
         "1",
         "-f",
         "mjpeg",
-        "-threads",
-        f"{max(1, cpu_no // 2)}",
         output,
     ]
     try:
@@ -542,8 +534,6 @@ class FFMpeg:
                 "libx264",
                 "-c:a",
                 "aac",
-                "-threads",
-                f"{max(1, cpu_no // 2)}",
                 output,
             ]
             if ext == "mp4":
@@ -566,8 +556,6 @@ class FFMpeg:
                 "0",
                 "-c",
                 "copy",
-                "-threads",
-                f"{max(1, cpu_no // 2)}",
                 output,
             ]
         if self._listener.is_cancelled:
@@ -613,8 +601,6 @@ class FFMpeg:
             "pipe:1",
             "-i",
             audio_file,
-            "-threads",
-            f"{max(1, cpu_no // 2)}",
             output,
         ]
         if self._listener.is_cancelled:
@@ -693,8 +679,6 @@ class FFMpeg:
             "libx264",
             "-c:a",
             "aac",
-            "-threads",
-            f"{max(1, cpu_no // 2)}",
             output_file,
         ]
 
@@ -758,8 +742,6 @@ class FFMpeg:
                 "-2",
                 "-c",
                 "copy",
-                "-threads",
-                f"{max(1, cpu_no // 2)}",
                 out_path,
             ]
             if not multi_streams:

--- a/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
@@ -11,7 +11,9 @@ from ...ext_utils.status_utils import (
 )
 
 
-async def get_download(nzo_id, old_info):
+async def get_download(nzo_id, old_info=None):
+    if old_info is None:
+        old_info = {}
     try:
         queue = await sabnzbd_client.get_downloads(nzo_ids=nzo_id)
         if res := queue["queue"]["slots"]:
@@ -61,26 +63,28 @@ class SabnzbdStatus:
         self.queued = queued
         self.listener = listener
         self._gid = gid
-        self._info = defaultdict(lambda: "")
+        self._info = {}
         self.engine = EngineStatus().STATUS_SABNZBD
 
     async def update(self):
         self._info = await get_download(self._gid, self._info)
 
     def progress(self):
-        return f"{self._info['percentage']}%"
+        return f"{self._info.get('percentage', '0')}%"
 
     def processed_raw(self):
-        return (float(self._info["mb"]) - float(self._info["mbleft"])) * 1048576
+        return (
+            float(self._info.get("mb", "0")) - float(self._info.get("mbleft", "0"))
+        ) * 1048576
 
     def processed_bytes(self):
         return get_readable_file_size(self.processed_raw())
 
     def speed_raw(self):
-        if self._info["mb"] == self._info["mbleft"]:
+        if self._info.get("mb", "0") == self._info.get("mbleft", "0"):
             return 0
         try:
-            return int(float(self._info["mbleft"]) * 1048576) / self.eta_raw()
+            return int(float(self._info.get("mbleft", "0")) * 1048576) / self.eta_raw()
         except Exception:
             return 0
 
@@ -88,22 +92,22 @@ class SabnzbdStatus:
         return f"{get_readable_file_size(self.speed_raw())}/s"
 
     def name(self):
-        return self._info["filename"]
+        return self._info.get("filename", "")
 
     def size(self):
-        return self._info["size"]
+        return self._info.get("size", 0)
 
     def eta_raw(self):
-        return int(time_to_seconds(self._info["timeleft"]))
+        return int(time_to_seconds(self._info.get("timeleft", "0")))
 
     def eta(self):
         return get_readable_time(self.eta_raw())
 
     async def status(self):
         await self.update()
-        if self._info["mb"] == self._info["mbleft"]:
+        if self._info.get("mb", "0") == self._info.get("mbleft", "0"):
             return MirrorStatus.STATUS_QUEUEDL
-        state = self._info["status"]
+        state = self._info.get("status")
         if state == "Paused" and self.queued:
             return MirrorStatus.STATUS_QUEUEDL
         elif state in [

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -247,6 +247,8 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
     elif key.startswith("nzbser"):
         index = int(key.replace("nzbser", ""))
         LOGGER.info(f"Data: {key}, {index}")
+        if index >= len(Config.USENET_SERVERS):
+            return await get_buttons("nzbserver")
         for k in list(Config.USENET_SERVERS[index].keys())[start : 10 + start]:
             buttons.data_button(k, f"botset nzbsevar{index} {k}")
         if state == "view":


### PR DESCRIPTION
## Summary by Sourcery

Harden NZB status handling, simplify media processing commands, improve torrent/NZB option initialization logging and robustness, and adjust settings and argument parsing edge cases.

Bug Fixes:
- Avoid errors in NZB status retrieval by defaulting to empty info when none is provided and using safe dictionary access for status fields.
- Fix argument parsing so the '-c' flag does not prematurely terminate option collection for subsequent arguments.
- Prevent NZB server settings navigation from failing when the selected index is out of range by redirecting back to the main NZB server menu.

Enhancements:
- Remove explicit FFmpeg thread options across media utilities to rely on default behavior and simplify command construction.
- Add informative logging when fetching qBittorrent, aria2, and SABnzbd options from their respective servers.
- Make SABnzbd option fetching more robust by retrying on errors until successful.