### PR TITLE
feat: limit ffmpeg threads to half of available cpus

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -214,6 +214,8 @@ async def take_ss(video_file, ss_nb) -> bool:
                 "1",
                 "-frames:v",
                 "1",
+            "-threads",
+            f"{max(1, cpu_no // 2)}",
                 output,
             ]
             cap_time += interval
@@ -252,6 +254,8 @@ async def get_audio_thumbnail(audio_file):
         "-an",
         "-vcodec",
         "copy",
+        "-threads",
+        f"{max(1, cpu_no // 2)}",
         output,
     ]
     try:
@@ -293,6 +297,8 @@ async def get_video_thumbnail(video_file, duration):
         "5",
         "-vframes",
         "1",
+        "-threads",
+        f"{max(1, cpu_no // 2)}",
         output,
     ]
     try:
@@ -343,6 +349,8 @@ async def get_multiple_frames_thumbnail(video_file, layout, keep_screenshots):
         "1",
         "-f",
         "mjpeg",
+        "-threads",
+        f"{max(1, cpu_no // 2)}",
         output,
     ]
     try:
@@ -534,6 +542,8 @@ class FFMpeg:
                 "libx264",
                 "-c:a",
                 "aac",
+                "-threads",
+                f"{max(1, cpu_no // 2)}",
                 output,
             ]
             if ext == "mp4":
@@ -556,6 +566,8 @@ class FFMpeg:
                 "0",
                 "-c",
                 "copy",
+                "-threads",
+                f"{max(1, cpu_no // 2)}",
                 output,
             ]
         if self._listener.is_cancelled:
@@ -601,6 +613,8 @@ class FFMpeg:
             "pipe:1",
             "-i",
             audio_file,
+            "-threads",
+            f"{max(1, cpu_no // 2)}",
             output,
         ]
         if self._listener.is_cancelled:
@@ -679,6 +693,8 @@ class FFMpeg:
             "libx264",
             "-c:a",
             "aac",
+            "-threads",
+            f"{max(1, cpu_no // 2)}",
             output_file,
         ]
 
@@ -742,6 +758,8 @@ class FFMpeg:
                 "-2",
                 "-c",
                 "copy",
+                "-threads",
+                f"{max(1, cpu_no // 2)}",
                 out_path,
             ]
             if not multi_streams:


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add configurable thread limits to ffmpeg invocations used for screenshots, thumbnails, conversions, sampling, and splitting to cap CPU usage per operation.