### PR TITLE
Minor Fix

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -522,11 +522,12 @@ class TaskListener(TaskConfig):
                         INDEX_URL = self.user_dict.get("INDEX_URL", "") or ""
                     elif Config.INDEX_URL:
                         INDEX_URL = Config.INDEX_URL
-                    if INDEX_URL:
-                        share_url = f"{INDEX_URL}findpath?id={dir_id}"
+                    if INDEX_URL and self.name:
+                        safe_name = rutils.quote(self.name.strip("/"))
+                        share_url = f"{INDEX_URL}/{safe_name}"
                         buttons.url_button("⚡ Index Link", share_url)
                         if mime_type.startswith(("image", "video", "audio")):
-                            share_urls = f"{INDEX_URL}findpath?id={dir_id}&view=true"
+                            share_urls = f"{share_url}?a=view"
                             buttons.url_button("🌐 View Link", share_urls)
                 button = buttons.build_menu(2)
             else:


### PR DESCRIPTION
Changed to old index link format, nomore findpath?id=xxx errors in index link

## Summary by Sourcery

Update generation of index and view URLs after upload completion to use a path-based link format instead of query parameters.

Enhancements:
- Adjust index link construction to include the task name in the path and rely on a safer, URL-encoded representation.
- Change media view link generation to build on the new index share URL with a simple view query parameter.