### PR TITLE
fix: rss arg issue and default rss size limit in bsetting

### DIFF
--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -195,7 +195,10 @@ def arg_parser(items, arg_base):
             else:
                 sub_list = []
                 for j in range(i + 1, total):
-                    if items[j] in arg_base and part != "-c" != items[j]:
+                    if items[j] in arg_base:
+                        if part == "-c" and items[j] == "-c":
+                            sub_list.append(items[j])
+                            continue
                         if part in bool_arg_set and not sub_list:
                             arg_base[part] = True
                             break

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -669,6 +669,8 @@ async def edit_bot_settings(client, query):
                     intervals["status"][key] = SetInterval(
                         value, update_status_message, key
                     )
+        elif data[2] == "RSS_SIZE_LIMIT":
+            value = 0
         elif data[2] == "EXCLUDED_EXTENSIONS":
             excluded_extensions.clear()
             excluded_extensions.extend(["aria2", "!qB"])


### PR DESCRIPTION
## Summary by Sourcery

Adjust argument parsing and RSS settings handling to fix RSS-related issues.

Bug Fixes:
- Correct argument parsing for the -c flag to ensure subsequent -c occurrences are handled properly.
- Set a default value for the RSS size limit setting in bot settings when selected.