### PR TITLE
Minor Updates

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -50,6 +50,8 @@ basicConfig(
 
 LOGGER = getLogger(__name__)
 cpu_no = cpu_count()
+threads = max(1, cpu_no // 2)
+cores = ",".join(str(i) for i in range(threads))
 
 bot_cache = {}
 DOWNLOAD_DIR = "/usr/src/app/downloads/"

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -140,7 +140,7 @@ class TaskConfig:
         self.thumb = None
         self.excluded_extensions = []
         self.files_to_proceed = []
-        self.is_super_chat = self.message.chat.type.name in ["SUPERGROUP", "CHANNEL"]
+        self.is_super_chat = self.message.chat.type.name in ["SUPERGROUP", "CHANNEL", "FORUM"]
         self.source_url = None
         self.bot_pm = Config.BOT_PM or self.user_dict.get("BOT_PM")
         self.pm_msg = None

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -13,6 +13,7 @@ from pyrogram.enums import ChatAction
 from .. import (
     DOWNLOAD_DIR,
     LOGGER,
+    cores,
     cpu_eater_lock,
     excluded_extensions,
     intervals,
@@ -140,7 +141,11 @@ class TaskConfig:
         self.thumb = None
         self.excluded_extensions = []
         self.files_to_proceed = []
-        self.is_super_chat = self.message.chat.type.name in ["SUPERGROUP", "CHANNEL", "FORUM"]
+        self.is_super_chat = self.message.chat.type.name in [
+            "SUPERGROUP",
+            "CHANNEL",
+            "FORUM",
+        ]
         self.source_url = None
         self.bot_pm = Config.BOT_PM or self.user_dict.get("BOT_PM")
         self.pm_msg = None
@@ -721,6 +726,9 @@ class TaskConfig:
             for ffmpeg_cmd in cmds:
                 self.proceed_count = 0
                 cmd = [
+                    "taskset",
+                    "-c",
+                    f"{cores}",
                     BinConfig.FFMPEG_NAME,
                     "-hide_banner",
                     "-loglevel",

--- a/bot/helper/ext_utils/files_utils.py
+++ b/bot/helper/ext_utils/files_utils.py
@@ -217,6 +217,8 @@ def get_mime_type(file_path):
 
 async def remove_excluded_files(fpath, ee):
     for root, _, files in await sync_to_async(walk, fpath):
+        if root.strip().endswith("/yt-dlp-thumb"):
+            continue
         for f in files:
             if f.strip().lower().endswith(tuple(ee)):
                 await remove(ospath.join(root, f))

--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -17,14 +17,12 @@ from time import time
 from aioshutil import rmtree
 from langcodes import Language
 
-from ... import LOGGER, cpu_no, DOWNLOAD_DIR
+from ... import LOGGER, DOWNLOAD_DIR, threads, cores
 from ...core.config_manager import BinConfig
 from .bot_utils import cmd_exec, sync_to_async
 from .files_utils import get_mime_type, is_archive, is_archive_split
 from .status_utils import time_to_seconds
 
-threads = max(1, cpu_no // 2)
-cores = ",".join(str(i) for i in range(threads))
 
 
 def get_md5_hash(up_path):
@@ -543,6 +541,9 @@ class FFMpeg:
         output = f"{base_name}.{ext}"
         if retry:
             cmd = [
+                "taskset",
+                "-c",
+                f"{cores}",
                 BinConfig.FFMPEG_NAME,
                 "-hide_banner",
                 "-loglevel",
@@ -569,6 +570,9 @@ class FFMpeg:
                 cmd[14:14] = ["-c:s", "copy"]
         else:
             cmd = [
+                "taskset",
+                "-c",
+                f"{cores}",
                 BinConfig.FFMPEG_NAME,
                 "-hide_banner",
                 "-loglevel",
@@ -620,6 +624,9 @@ class FFMpeg:
         base_name = ospath.splitext(audio_file)[0]
         output = f"{base_name}.{ext}"
         cmd = [
+            "taskset",
+            "-c",
+            f"{cores}",
             BinConfig.FFMPEG_NAME,
             "-hide_banner",
             "-loglevel",
@@ -690,6 +697,9 @@ class FFMpeg:
         filter_complex += f"concat=n={len(segments)}:v=1:a=1[vout][aout]"
 
         cmd = [
+            "taskset",
+            "-c",
+            f"{cores}",
             BinConfig.FFMPEG_NAME,
             "-hide_banner",
             "-loglevel",
@@ -751,6 +761,9 @@ class FFMpeg:
         while i <= parts or start_time < duration - 4:
             out_path = f_path.replace(file_, f"{base_name}.part{i:03}{extension}")
             cmd = [
+                "taskset",
+                "-c",
+                f"{cores}",
                 BinConfig.FFMPEG_NAME,
                 "-hide_banner",
                 "-loglevel",

--- a/bot/helper/mirror_leech_utils/download_utils/yt_dlp_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/yt_dlp_download.py
@@ -57,6 +57,7 @@ class YoutubeDLHelper:
         self._gid = ""
         self._ext = ""
         self.is_playlist = False
+        self.keep_thumb = False
         self.playlist_count = 0
         self.opts = {
             "progress_hooks": [self._on_download_progress],
@@ -243,6 +244,9 @@ class YoutubeDLHelper:
             else:
                 self._ext = f".{audio_format}"
 
+        if not self._listener.is_leech or self._listener.thumbnail_layout:
+            self.opts["writethumbnail"] = False
+
         if options:
             self._set_options(options)
 
@@ -262,15 +266,16 @@ class YoutubeDLHelper:
             )
             base_name = ospath.splitext(self._listener.name)[0]
 
+        start_path = path if self.keep_thumb else f"{path}/yt-dlp-thumb"
         if self.is_playlist:
             self.opts["outtmpl"] = {
                 "default": f"{path}/{self._listener.name}/%(title,fulltitle,alt_title)s%(season_number& |)s%(season_number&S|)s%(season_number|)02d%(episode_number&E|)s%(episode_number|)02d%(height& |)s%(height|)s%(height&p|)s%(fps|)s%(fps&fps|)s%(tbr& |)s%(tbr|)d.%(ext)s",
-                "thumbnail": f"{path}/yt-dlp-thumb/%(title,fulltitle,alt_title)s%(season_number& |)s%(season_number&S|)s%(season_number|)02d%(episode_number&E|)s%(episode_number|)02d%(height& |)s%(height|)s%(height&p|)s%(fps|)s%(fps&fps|)s%(tbr& |)s%(tbr|)d.%(ext)s",
+                "thumbnail": f"{start_path}/%(title,fulltitle,alt_title)s%(season_number& |)s%(season_number&S|)s%(season_number|)02d%(episode_number&E|)s%(episode_number|)02d%(height& |)s%(height|)s%(height&p|)s%(fps|)s%(fps&fps|)s%(tbr& |)s%(tbr|)d.%(ext)s",
             }
         elif "download_ranges" in options:
             self.opts["outtmpl"] = {
                 "default": f"{path}/{base_name}/%(section_number|)s%(section_number&.|)s%(section_title|)s%(section_title&-|)s%(title,fulltitle,alt_title)s %(section_start)s to %(section_end)s.%(ext)s",
-                "thumbnail": f"{path}/yt-dlp-thumb/%(section_number|)s%(section_number&.|)s%(section_title|)s%(section_title&-|)s%(title,fulltitle,alt_title)s %(section_start)s to %(section_end)s.%(ext)s",
+                "thumbnail": f"{start_path}/%(section_number|)s%(section_number&.|)s%(section_title|)s%(section_title&-|)s%(title,fulltitle,alt_title)s %(section_start)s to %(section_end)s.%(ext)s",
             }
         elif any(
             key in options
@@ -280,25 +285,26 @@ class YoutubeDLHelper:
                 "writeannotations",
                 "writedesktoplink",
                 "writewebloclink",
+                "writelink",
                 "writeurllink",
                 "writesubtitles",
-                "writeautomaticsub",
+                "write_all_thumbnails",
             ]
         ):
             self.opts["outtmpl"] = {
                 "default": f"{path}/{base_name}/{self._listener.name}",
-                "thumbnail": f"{path}/yt-dlp-thumb/{base_name}.%(ext)s",
+                "thumbnail": f"{start_path}/{base_name}.%(ext)s",
             }
         else:
             self.opts["outtmpl"] = {
                 "default": f"{path}/{self._listener.name}",
-                "thumbnail": f"{path}/yt-dlp-thumb/{base_name}.%(ext)s",
+                "thumbnail": f"{start_path}/{base_name}.%(ext)s",
             }
 
         if qual.startswith("ba/b"):
             self._listener.name = f"{base_name}{self._ext}"
 
-        if self._listener.is_leech and not self._listener.thumbnail_layout:
+        if self.opts["writethumbnail"]:
             self.opts["postprocessors"].append(
                 {
                     "format": "jpg",
@@ -320,14 +326,10 @@ class YoutubeDLHelper:
         ]:
             self.opts["postprocessors"].append(
                 {
-                    "already_have_thumbnail": bool(
-                        self._listener.is_leech and not self._listener.thumbnail_layout
-                    ),
+                    "already_have_thumbnail": self.opts["writethumbnail"],
                     "key": "EmbedThumbnail",
                 }
             )
-        elif not self._listener.is_leech:
-            self.opts["writethumbnail"] = False
 
         msg, button = await stop_duplicate_check(self._listener)
         if msg:
@@ -372,4 +374,6 @@ class YoutubeDLHelper:
                 if isinstance(value, list):
                     self.opts[key] = lambda info, ytdl: value
             else:
+                if key == "writethumbnail" and value is True:
+                    self.keep_thumb = True
                 self.opts[key] = value

--- a/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
@@ -479,6 +479,8 @@ class TelegramUploader:
                 thumb_path = f"{self._path}/yt-dlp-thumb/{file_name}.jpg"
                 if await aiopath.isfile(thumb_path):
                     thumb = thumb_path
+                elif await aiopath.isfile(thumb_path.replace("/yt-dlp-thumb", "")):
+                    thumb = thumb_path.replace("/yt-dlp-thumb", "")
                 elif is_audio and not is_video:
                     thumb = await get_audio_thumbnail(self._up_path)
 


### PR DESCRIPTION
## Summary by Sourcery

Improve media processing performance and thumbnail handling across downloads and uploads.

New Features:
- Allow keeping original yt-dlp thumbnails alongside downloads when explicitly requested.
- Support recognizing forum chats as "super" chats for special handling.

Bug Fixes:
- Ensure yt-dlp thumbnail writing and embedding options are consistently aligned with listener settings.
- Skip deleting files in yt-dlp thumbnail directories when removing excluded files so thumbnails are preserved.
- Fallback to using media files in the main download directory as thumbnails if dedicated thumbnail files are missing during Telegram uploads.

Enhancements:
- Centralize CPU core and thread configuration and apply taskset-based CPU pinning to all ffmpeg-related commands for better resource control.
- Simplify yt-dlp thumbnail postprocessor configuration by driving behavior from writethumbnail option instead of listener-specific flags.