### PR TITLE
fix: bulk logic

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -637,7 +637,7 @@ class TaskConfig:
             index = self.options.index("-b")
             del self.options[index]
             if bulk_start or bulk_end:
-                del self.options[index + 1]
+                del self.options[index]
             self.options = " ".join(self.options)
             b_msg.append(f"{self.bulk[0]} -i {len(self.bulk)} {self.options}")
             msg = " ".join(b_msg)

--- a/bot/helper/ext_utils/bulk_links.py
+++ b/bot/helper/ext_utils/bulk_links.py
@@ -2,22 +2,18 @@ from aiofiles import open as aiopen
 from aiofiles.os import remove
 
 
-def filter_links(links_list: list, bulk_start: int, bulk_end: int) -> list:
-    if bulk_start != 0 and bulk_end != 0:
-        links_list = links_list[bulk_start:bulk_end]
-    elif bulk_start != 0:
-        links_list = links_list[bulk_start:]
-    elif bulk_end != 0:
-        links_list = links_list[:bulk_end]
-    return links_list
+def filter_links(links_list, bulk_start, bulk_end):
+    start = bulk_start if bulk_start > 0 else None
+    end = bulk_end if bulk_end > 0 else None
+    return links_list[start:end]
 
 
-def get_links_from_message(text: str) -> list:
+def get_links_from_message(text):
     links_list = text.split("\n")
     return [item.strip() for item in links_list if len(item) != 0]
 
 
-async def get_links_from_file(message) -> list:
+async def get_links_from_file(message):
     links_list = []
     text_file_dir = await message.download()
     async with aiopen(text_file_dir, "r+") as f:
@@ -27,7 +23,7 @@ async def get_links_from_file(message) -> list:
     return links_list
 
 
-async def extract_bulk_links(message, bulk_start: str, bulk_end: str) -> list:
+async def extract_bulk_links(message, bulk_start, bulk_end):
     bulk_start = int(bulk_start)
     bulk_end = int(bulk_end)
     links_list = []


### PR DESCRIPTION
## Summary by Sourcery

Adjust bulk link handling to correctly slice input links and clean up bulk option parsing.

Bug Fixes:
- Fix link filtering logic to handle optional bulk start and end positions more reliably.
- Correct bulk options list cleanup when initializing bulk operations to avoid leaving stray arguments.