### PR TITLE
fix convert and split after adding taskset

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -562,11 +562,11 @@ class FFMpeg:
                 output,
             ]
             if ext == "mp4":
-                cmd[14:14] = ["-c:s", "mov_text"]
+                cmd[17:17] = ["-c:s", "mov_text"]
             elif ext == "mkv":
-                cmd[14:14] = ["-c:s", "ass"]
+                cmd[17:17] = ["-c:s", "ass"]
             else:
-                cmd[14:14] = ["-c:s", "copy"]
+                cmd[17:17] = ["-c:s", "copy"]
         else:
             cmd = [
                 "taskset",
@@ -790,8 +790,8 @@ class FFMpeg:
                 out_path,
             ]
             if not multi_streams:
-                del cmd[12]
-                del cmd[12]
+                del cmd[15]
+                del cmd[15]
             if self._listener.is_cancelled:
                 return False
             self._listener.subproc = await create_subprocess_exec(

--- a/bot/helper/mirror_leech_utils/download_utils/jd_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/jd_download.py
@@ -163,8 +163,10 @@ async def add_jd_download(listener, path):
                 )
 
             await sleep(1)
+            LOGGER.info(f"JDownloader Collecting Data: {listener.link}")
             while await jdownloader.device.linkgrabber.is_collecting():
-                pass
+                await sleep(0.5)
+            LOGGER.info(f"JDownloader Finished Collecting Data: {listener.link}")
             start_time = time()
             online_packages = []
             corrupted_packages = []


### PR DESCRIPTION
## Summary by Sourcery

Adjust media processing commands to account for taskset arguments and improve JDownloader collection handling.

Bug Fixes:
- Correct subtitle codec and multi-stream option indices in video conversion and splitting commands after introducing taskset arguments.
- Prevent busy-waiting during JDownloader link collection by adding periodic sleeps.

Enhancements:
- Add logging around JDownloader link collection start and completion for better observability.