### PR TITLE
feat: Make Gofile Folder id Optional

### DIFF
--- a/bot/helper/mirror_leech_utils/uphoster_utils/gofile_utils/upload.py
+++ b/bot/helper/mirror_leech_utils/uphoster_utils/gofile_utils/upload.py
@@ -339,7 +339,7 @@ class GoFileUpload:
         try:
             account_data = await self.__getAccount()
         except Exception as e:
-            raise Exception(f"Invalid GoFile API Key: {e}")
+            raise Exception(f"GoFile Account Error: {e}") from e
 
         if await aiopath.isfile(self._path):
             # Single file upload

--- a/bot/modules/users_settings.py
+++ b/bot/modules/users_settings.py
@@ -270,7 +270,7 @@ Here I will explain how to use mltb.* which is reference to files you want to wo
     "GOFILE_FOLDER_ID": (
         "String",
         "Gofile Folder ID",
-        "<i>Send your Gofile Folder ID.</i> \n┖ <b>Time Left :</b> <code>60 sec</code>",
+        "<i>Send your Gofile Folder ID. If empty, uploads to Root.</i> \n┖ <b>Time Left :</b> <code>60 sec</code>",
     ),
     "BUZZHEAVIER_TOKEN": (
         "String",
@@ -614,7 +614,7 @@ async def get_user_settings(from_user, stype="main"):
         elif Config.GOFILE_FOLDER_ID:
             gffolder = Config.GOFILE_FOLDER_ID
         else:
-            gffolder = "None"
+            gffolder = "None (Uploads to Root)"
 
         text = f"""⌬ <b>Gofile Settings :</b>
 ┟ <b>Name</b> → {user_name}


### PR DESCRIPTION
## Summary by Sourcery

Make GoFile uploads work when no folder ID is configured by defaulting to the account root folder and adjust user-facing settings text accordingly.

New Features:
- Allow GoFile uploads to default to the account root folder when no folder ID is provided.

Bug Fixes:
- Improve GoFile API key validation by relying on account retrieval and surfacing clearer error messages.

Enhancements:
- Refine user settings descriptions for GoFile to explain behavior when the folder ID is not set.