### PR TITLE
Fix : RetryError[Future at * state=finished raised HttpError]

### DIFF
--- a/bot/helper/mirror_leech_utils/gdrive_utils/helper.py
+++ b/bot/helper/mirror_leech_utils/gdrive_utils/helper.py
@@ -1,6 +1,5 @@
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.http import build_http
 from logging import getLogger, ERROR
@@ -121,29 +120,6 @@ class GoogleDriveHelper:
         parsed = urlparse(link)
         return parse_qs(parsed.query)["id"][0]
 
-    def set_permission(self, file_id):
-        permissions = {
-            "role": "reader",
-            "type": "anyone",
-            "value": None,
-            "withLink": True,
-        }
-        try:
-            return (
-                self.service.permissions()
-                .create(fileId=file_id, body=permissions, supportsAllDrives=True)
-                .execute()
-            )
-        except HttpError as err:
-            if err.resp.get("content-type", "").startswith("application/json"):
-                reason = (
-                    eval(err.content).get("error").get("errors")[0].get("reason")
-                )
-                if reason == "cannotModifyInheritedPermission":
-                    LOGGER.warning(f"Encountered 403 Forbidden with reason \"{reason}\"")
-                    return
-            raise err
-
     @retry(
         wait=wait_exponential(multiplier=2, min=3, max=6),
         stop=stop_after_attempt(3),
@@ -214,8 +190,6 @@ class GoogleDriveHelper:
             .execute()
         )
         file_id = file.get("id")
-        if not Config.IS_TEAM_DRIVE:
-            self.set_permission(file_id)
         LOGGER.info(f"Created G-Drive Folder:\nName: {file.get('name')}\nID: {file_id}")
         return file_id
 

--- a/bot/helper/mirror_leech_utils/gdrive_utils/helper.py
+++ b/bot/helper/mirror_leech_utils/gdrive_utils/helper.py
@@ -1,5 +1,6 @@
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.http import build_http
 from logging import getLogger, ERROR
@@ -120,6 +121,29 @@ class GoogleDriveHelper:
         parsed = urlparse(link)
         return parse_qs(parsed.query)["id"][0]
 
+    def set_permission(self, file_id):
+        permissions = {
+            "role": "reader",
+            "type": "anyone",
+            "value": None,
+            "withLink": True,
+        }
+        try:
+            return (
+                self.service.permissions()
+                .create(fileId=file_id, body=permissions, supportsAllDrives=True)
+                .execute()
+            )
+        except HttpError as err:
+            if err.resp.get("content-type", "").startswith("application/json"):
+                reason = (
+                    eval(err.content).get("error").get("errors")[0].get("reason")
+                )
+                if reason == "cannotModifyInheritedPermission":
+                    LOGGER.warning(f"Encountered 403 Forbidden with reason \"{reason}\"")
+                    return
+            raise err
+
     @retry(
         wait=wait_exponential(multiplier=2, min=3, max=6),
         stop=stop_after_attempt(3),
@@ -190,6 +214,8 @@ class GoogleDriveHelper:
             .execute()
         )
         file_id = file.get("id")
+        if not Config.IS_TEAM_DRIVE:
+            self.set_permission(file_id)
         LOGGER.info(f"Created G-Drive Folder:\nName: {file.get('name')}\nID: {file_id}")
         return file_id
 

--- a/bot/helper/mirror_leech_utils/gdrive_utils/upload.py
+++ b/bot/helper/mirror_leech_utils/gdrive_utils/upload.py
@@ -145,9 +145,6 @@ class GoogleDriveUpload(GoogleDriveHelper):
                 )
                 .execute()
             )
-            if not Config.IS_TEAM_DRIVE:
-                self.set_permission(response["id"])
-
             drive_file = (
                 self.service.files()
                 .get(fileId=response["id"], supportsAllDrives=True)
@@ -207,8 +204,6 @@ class GoogleDriveUpload(GoogleDriveHelper):
         except Exception:
             pass
         self.file_processed_bytes = 0
-        if not Config.IS_TEAM_DRIVE:
-            self.set_permission(response["id"])
         if not in_dir:
             drive_file = (
                 self.service.files()

--- a/bot/helper/mirror_leech_utils/gdrive_utils/upload.py
+++ b/bot/helper/mirror_leech_utils/gdrive_utils/upload.py
@@ -145,6 +145,9 @@ class GoogleDriveUpload(GoogleDriveHelper):
                 )
                 .execute()
             )
+            if not Config.IS_TEAM_DRIVE:
+                self.set_permission(response["id"])
+
             drive_file = (
                 self.service.files()
                 .get(fileId=response["id"], supportsAllDrives=True)
@@ -204,6 +207,8 @@ class GoogleDriveUpload(GoogleDriveHelper):
         except Exception:
             pass
         self.file_processed_bytes = 0
+        if not Config.IS_TEAM_DRIVE:
+            self.set_permission(response["id"])
         if not in_dir:
             drive_file = (
                 self.service.files()


### PR DESCRIPTION
With regards to #464 

This pull request updates the Google Drive permission handling logic in `gdrive_utils/helper.py` to improve error handling when setting file permissions. The main change is the addition of specific handling for a particular Google API error, which prevents unnecessary retries and logs a warning when an inherited permission cannot be modified.

**Improvements to error handling:**

* Added an import for `HttpError` from `googleapiclient.errors` to enable more granular exception handling when interacting with the Google Drive API.
* Updated the `set_permission` method to catch `HttpError` exceptions. If the error is due to a `cannotModifyInheritedPermission` reason (typically a 403 Forbidden), the method now logs a warning and returns early instead of retrying or raising the error. Other errors are still raised.


The bot tries to make the files public inside of TeamDrive.
It shouldn't try to override the parent folder's permission level , but it does it at ```/bot/helper/mirror_leech_utils/gdrive_utils/helper.py```

```
def set_permission(self, file_id):
        permissions = {
            "role": "reader",
            "type": "anyone",
            "value": None,
            "withLink": True,
        }
```
Just logging the error and continuing, uploads the task successfully.

This commit is not merge-ready. It just gives the idea for bug-fixing. Changes to the commits may or may not be required.

It contains 2 commits which show removing the set_permission func , for its absence the Google Drive api should use the parent folders permissions.

## Summary by Sourcery

Improve Google Drive permission handling to gracefully handle inherited-permission errors when setting file visibility.

Bug Fixes:
- Avoid unnecessary retries and failures when attempting to modify Google Drive permissions that cannot be changed due to inherited access controls.

Enhancements:
- Handle specific Google API HttpError responses in set_permission by logging and skipping non-modifiable inherited permissions while propagating other errors.