### PR TITLE
fix: Increase Telegram filename limit

### DIFF
--- a/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
@@ -230,7 +230,7 @@ class TelegramUploader:
                 cap_mono,
             )
 
-        if len(file_) > 56:
+        if len(file_) > 255:
             if is_archive(file_):
                 name = get_base_name(file_)
                 ext = file_.split(name, 1)[1]
@@ -245,7 +245,7 @@ class TelegramUploader:
                 ext = ""
             if self._lsuffix:
                 ext = f"{self._lsuffix}{ext}"
-            name = name[: 56 - len(ext)]
+            name = name[: 255 - len(ext)]
             file_ = f"{name}{ext}"
         elif self._lsuffix:
             name, ext = ospath.splitext(file_)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Adjust filename truncation logic so long filenames are preserved up to 255 characters when uploading to Telegram.