### PR TITLE
Gofile Fix

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -1229,7 +1229,7 @@ def gofile(url):
     def __fetch_links(session, _id, folderPath="", retry=True):
         _url = f"https://api.gofile.io/contents/{_id}?cache=true"
         time_slot = int(time()) // 14400
-        raw = f"{user_agent}::en-US::{token}::{time_slot}::f4s58gs6"
+        raw = f"{user_agent}::en-US::{token}::{time_slot}::5d4f7g8sd45fsd"
         wt = sha256(raw.encode()).hexdigest()
         headers = {
             "User-Agent": user_agent,


### PR DESCRIPTION
Update token format in fetch_links function

## Summary by Sourcery

Bug Fixes:
- Adjust the token hash input used in Gofile link fetching to match the updated API requirements and restore link retrieval.