### PR TITLE
Pixeldrain (Fix)

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -695,10 +695,13 @@ def onedrive(link):
 def pixeldrain(url):
     try:
         url = url.rstrip("/")
-        code = url.split("/")[-1].split("?", 1)[0]
-        response = get("https://pd.cybar.xyz/", allow_redirects=True)
-        return response.url + code
-    except Exception as e:
+        if "pixeldrain" not in url:
+            raise DirectDownloadLinkException("ERROR: Not a Pixeldrain link")
+        parts = url.split("/")
+        code = parts[-1].split("?", 1)[0]
+        domain = parts[2]
+        return f"https://{domain}/api/file/{code}"
+    except Exception:
         raise DirectDownloadLinkException("ERROR: Direct link not found")
 
 


### PR DESCRIPTION
Removed old domain, it won't works for pixeldrain redirects

## Summary by Sourcery

Bug Fixes:
- Fix Pixeldrain link handling by validating Pixeldrain URLs and constructing direct API file links from the source domain instead of relying on a broken third-party redirect.