### PR TITLE
Update pixeldrain function to use new API endpoint

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -696,11 +696,11 @@ def pixeldrain(url):
     try:
         url = url.rstrip("/")
         code = url.split("/")[-1].split("?", 1)[0]
-        response = get("https://pd.cybar.xyz/", allow_redirects=True)
+        response = get(f"https://{url.split('/')[2]}/api/file/", allow_redirects=True)
         return response.url + code
     except Exception as e:
         raise DirectDownloadLinkException("ERROR: Direct link not found")
-
+        
 
 def streamtape(url):
     splitted_url = url.split("/")


### PR DESCRIPTION
Fixed

## Summary by Sourcery

Bug Fixes:
- Fix pixeldrain direct link generation by constructing URLs against the original host’s /api/file/ endpoint rather than a fixed external service.