### PR TITLE
Added Merging Video Feature

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -299,6 +299,8 @@ class TaskConfig:
             )
         if not self.merge_video:
             self.merge_video = bool(self.user_dict.get("MERGE_VIDEO", False))
+
+        if not self.is_leech:
             default_upload = (
                 self.user_dict.get("DEFAULT_UPLOAD", "") or Config.DEFAULT_UPLOAD
             )

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -297,6 +297,8 @@ class TaskConfig:
                 or "STOP_DUPLICATE" not in self.user_dict
                 and Config.STOP_DUPLICATE
             )
+        if not self.merge_video:
+            self.merge_video = bool(self.user_dict.get("MERGE_VIDEO", False))
             default_upload = (
                 self.user_dict.get("DEFAULT_UPLOAD", "") or Config.DEFAULT_UPLOAD
             )

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -49,6 +49,7 @@ from .ext_utils.media_utils import (
     get_document_type,
     take_ss,
 )
+from .ext_utils.merge_utils import MergeVideos
 from .ext_utils.metadata_utils import MetadataProcessor
 from .mirror_leech_utils.gdrive_utils.list import GoogleDriveList
 from .mirror_leech_utils.rclone_utils.list import RcloneList
@@ -121,6 +122,7 @@ class TaskConfig:
         self.private_link = False
         self.stop_duplicate = False
         self.sample_video = False
+        self.merge_video = False
         self.convert_audio = False
         self.convert_video = False
         self.screen_shots = False
@@ -1095,6 +1097,19 @@ class TaskConfig:
                             move(res, f"{new_folder}/SAMPLE.{file_}"),
                         )
                         return new_folder
+        return dl_path
+
+    async def proceed_merge(self, dl_path, gid):
+        if self.is_file:
+            return dl_path
+        merger = MergeVideos(self)
+        self.progress = False
+        async with cpu_eater_lock:
+            self.progress = True
+            LOGGER.info(f"Merging videos: {self.name}")
+            await merger.merge(dl_path, gid)
+        if self.is_cancelled:
+            return False
         return dl_path
 
     async def proceed_compress(self, dl_path, gid):

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -1110,7 +1110,6 @@ class TaskConfig:
         self.progress = False
         async with cpu_eater_lock:
             self.progress = True
-            LOGGER.info(f"Merging videos: {self.name}")
             await merger.merge(dl_path, gid)
         if self.is_cancelled:
             return False

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -144,6 +144,7 @@ def arg_parser(items, arg_base):
         "-j",
         "-d",
         "-sv",
+        "-mv",
         "-ss",
         "-f",
         "-fd",

--- a/bot/helper/ext_utils/help_messages.py
+++ b/bot/helper/ext_utils/help_messages.py
@@ -159,6 +159,12 @@ Create sample video for one video or folder of videos.
 /cmd -sv (it will take the default values which 60sec sample duration and part duration is 4sec).
 You can control those values. Example: /cmd -sv 70:5(sample-duration:part-duration) or /cmd -sv :5 or /cmd -sv 70."""
 
+merge_video = """<b>Merge Videos</b>: -mv
+
+Merge all videos in a folder into a single .mkv file using ffmpeg concat.
+/cmd link -mv
+Note: Only works on folders with multiple video files. Files are sorted naturally before merging."""
+
 screenshot = """<b>ScreenShots</b>: -ss
 
 Create screenshots for one video or folder of videos.
@@ -298,6 +304,7 @@ YT_HELP_DICT = {
     "Rclone-Flags": rcf,
     "Bulk": bulk,
     "Sample-Video": sample_video,
+    "Merge-Video": merge_video,
     "Screenshot": screenshot,
     "Convert-Media": convert_media,
     "Force-Start": force_start,
@@ -328,6 +335,7 @@ MIRROR_HELP_DICT = {
     "Rclone-DL": rlone_dl,
     "Tg-Links": tg_links,
     "Sample-Video": sample_video,
+    "Merge-Video": merge_video,
     "Screenshot": screenshot,
     "Convert-Media": convert_media,
     "Force-Start": force_start,

--- a/bot/helper/ext_utils/merge_utils.py
+++ b/bot/helper/ext_utils/merge_utils.py
@@ -79,7 +79,6 @@ class MergeVideos:
             await f.write("\n".join(video_files))
 
         outfile = f"{ospath.join(path, name)}.mkv"
-        LOGGER.info(f"Merging {len(video_files)} videos -> {name}")
 
         cmd = [
             BinConfig.FFMPEG_NAME,

--- a/bot/helper/ext_utils/merge_utils.py
+++ b/bot/helper/ext_utils/merge_utils.py
@@ -1,0 +1,118 @@
+from asyncio import create_subprocess_exec, ensure_future, gather, sleep
+from aiofiles import open as aiopen
+from aiofiles.os import path as aiopath, remove
+from natsort import natsorted
+from os import path as ospath, walk
+from time import time
+
+from ... import LOGGER, task_dict, task_dict_lock
+from ...core.config_manager import BinConfig
+from ..ext_utils.bot_utils import sync_to_async
+from ..ext_utils.files_utils import get_path_size
+from ..ext_utils.media_utils import get_document_type
+from ..mirror_leech_utils.status_utils.merge_status import MergeStatus
+from ..telegram_helper.message_utils import update_status_message
+
+
+class MergeVideos:
+    def __init__(self, listener):
+        self._listener = listener
+        self._processed_bytes = 0
+        self._start_time = time()
+
+    @property
+    def processed_bytes(self):
+        return self._processed_bytes
+
+    @property
+    def speed_raw(self):
+        elapsed = time() - self._start_time
+        return self._processed_bytes / elapsed if elapsed > 0 else 0
+
+    @property
+    def progress_raw(self):
+        try:
+            return self._processed_bytes / self._listener.size * 100
+        except ZeroDivisionError:
+            return 0
+
+    @property
+    def eta_raw(self):
+        try:
+            remaining = self._listener.size - self._processed_bytes
+            return remaining / self.speed_raw
+        except (ZeroDivisionError, ValueError):
+            return 0
+
+    async def _track_progress(self, outfile):
+        while not self._listener.is_cancelled:
+            await sleep(1)
+            if await aiopath.exists(outfile):
+                self._processed_bytes = await get_path_size(outfile)
+
+    async def merge(self, path, gid):
+        video_files, remove_files = [], []
+        total_size = 0
+
+        for dirpath, _, files in await sync_to_async(walk, path):
+            for file in natsorted(files):
+                fpath = ospath.join(dirpath, file)
+                is_video, _, _ = await get_document_type(fpath)
+                if is_video:
+                    fsize = await get_path_size(fpath)
+                    total_size += fsize
+                    video_files.append(f"file '{fpath}'")
+                    remove_files.append(fpath)
+
+        if len(video_files) <= 1:
+            return True
+
+        name = ospath.basename(path)
+        self._listener.size = total_size
+
+        async with task_dict_lock:
+            task_dict[self._listener.mid] = MergeStatus(self._listener, self, gid)
+        await update_status_message(self._listener.message.chat.id)
+
+        input_file = ospath.join(path, "input.txt")
+        async with aiopen(input_file, "w") as f:
+            await f.write("\n".join(video_files))
+
+        outfile = f"{ospath.join(path, name)}.mkv"
+        LOGGER.info(f"Merging {len(video_files)} videos -> {name}")
+
+        cmd = [
+            BinConfig.FFMPEG_NAME,
+            "-ignore_unknown",
+            "-loglevel",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            input_file,
+            "-map",
+            "0",
+            "-c",
+            "copy",
+            outfile,
+        ]
+
+        self._listener.subproc = await create_subprocess_exec(*cmd)
+        tracker = ensure_future(self._track_progress(outfile))
+        code = await self._listener.subproc.wait()
+        tracker.cancel()
+
+        if self._listener.is_cancelled or code == -9:
+            return False
+
+        if code == 0:
+            await remove(input_file)
+            if not self._listener.seed:
+                await gather(*[remove(f) for f in remove_files])
+            LOGGER.info(f"Merged successfully: {name}.mkv")
+        else:
+            LOGGER.error(f"Merge failed for: {name}.mkv")
+
+        return True

--- a/bot/helper/ext_utils/merge_utils.py
+++ b/bot/helper/ext_utils/merge_utils.py
@@ -74,7 +74,7 @@ class MergeVideos:
             task_dict[self._listener.mid] = MergeStatus(self._listener, self, gid)
         await update_status_message(self._listener.message.chat.id)
 
-        input_file = ospath.join(path, "input.txt")
+        input_file = ospath.join(path, "madara.txt")
         async with aiopen(input_file, "w") as f:
             await f.write("\n".join(video_files))
 

--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -36,6 +36,7 @@ class MirrorStatus:
     STATUS_FFMPEG = "FFmpeg"
     STATUS_YT = "YouTube"
     STATUS_METADATA = "Metadata"
+    STATUS_MERGING = "Merging"
 
 
 class EngineStatus:
@@ -73,6 +74,7 @@ STATUSES = {
     "SP": MirrorStatus.STATUS_SPLIT,
     "SV": MirrorStatus.STATUS_SAMVID,
     "FF": MirrorStatus.STATUS_FFMPEG,
+    "MG": MirrorStatus.STATUS_MERGING,
     "PA": MirrorStatus.STATUS_PAUSED,
     "CK": MirrorStatus.STATUS_CHECK,
 }

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -221,6 +221,15 @@ class TaskListener(TaskConfig):
         if self.join and not self.is_file:
             await join_files(up_path)
 
+        if self.merge_video and not self.is_file:
+            up_path = await self.proceed_merge(up_path, gid)
+            if self.is_cancelled:
+                return
+            self.is_file = await aiopath.isfile(up_path)
+            self.name = up_path.replace(f"{up_dir}/", "").split("/", 1)[0]
+            self.size = await get_path_size(up_dir)
+            self.clear()
+
         if self.extract and not self.is_nzb:
             up_path = await self.proceed_extract(up_path, gid)
             if self.is_cancelled:

--- a/bot/helper/mirror_leech_utils/status_utils/merge_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/merge_status.py
@@ -1,0 +1,55 @@
+from .... import LOGGER
+from ...ext_utils.status_utils import (
+    EngineStatus,
+    MirrorStatus,
+    get_readable_file_size,
+    get_readable_time,
+)
+
+
+class MergeStatus:
+    def __init__(self, listener, obj, gid):
+        self.listener = listener
+        self._obj = obj
+        self._gid = gid
+        self.engine = EngineStatus().STATUS_FFMPEG
+
+    def gid(self):
+        return self._gid
+
+    def name(self):
+        return self.listener.name
+
+    def size(self):
+        return get_readable_file_size(self.listener.size)
+
+    def processed_bytes(self):
+        return get_readable_file_size(self._obj.processed_bytes)
+
+    def progress(self):
+        return f"{round(self._obj.progress_raw, 2)}%"
+
+    def speed(self):
+        return f"{get_readable_file_size(self._obj.speed_raw)}/s"
+
+    def eta(self):
+        return get_readable_time(self._obj.eta_raw) if self._obj.eta_raw else "-"
+
+    def status(self):
+        return MirrorStatus.STATUS_MERGING
+
+    def task(self):
+        return self
+
+    async def cancel_task(self):
+        LOGGER.info(f"Cancelling Merge: {self.listener.name}")
+        self.listener.is_cancelled = True
+        if (
+            self.listener.subproc is not None
+            and self.listener.subproc.returncode is None
+        ):
+            try:
+                self.listener.subproc.kill()
+            except Exception:
+                pass
+        await self.listener.on_upload_error("Merge stopped by user!")

--- a/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
@@ -174,7 +174,7 @@ class TelegramUploader:
         cap_file_ = file_ = pre_file_
 
         if self._lprefix:
-            cap_file_ = self._lprefix.replace(r"\s", " ") + file_
+            cap_file_ = self._lprefix.replace(r"\s", " ").rstrip() + " " + file_
             self._lprefix = re_sub(r"<.*?>", "", self._lprefix).replace(r"\s", " ").rstrip()
             if not file_.startswith(self._lprefix):
                 file_ = f"{self._lprefix} {file_}"

--- a/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
@@ -175,14 +175,14 @@ class TelegramUploader:
 
         if self._lprefix:
             cap_file_ = self._lprefix.replace(r"\s", " ") + file_
-            self._lprefix = re_sub(r"<.*?>", "", self._lprefix).replace(r"\s", " ")
+            self._lprefix = re_sub(r"<.*?>", "", self._lprefix).replace(r"\s", " ").rstrip()
             if not file_.startswith(self._lprefix):
-                file_ = f"{self._lprefix}{file_}"
+                file_ = f"{self._lprefix} {file_}"
 
         if self._lsuffix:
             name, ext = ospath.splitext(cap_file_)
-            cap_file_ = name + self._lsuffix.replace(r"\s", " ") + ext
-            self._lsuffix = re_sub(r"<.*?>", "", self._lsuffix).replace(r"\s", " ")
+            self._lsuffix = re_sub(r"<.*?>", "", self._lsuffix).replace(r"\s", " ").lstrip()
+            cap_file_ = name + " " + self._lsuffix + ext
 
         cap_mono = (
             f"<{Config.LEECH_FONT}>{cap_file_}</{Config.LEECH_FONT}>"
@@ -244,12 +244,12 @@ class TelegramUploader:
                 name = file_
                 ext = ""
             if self._lsuffix:
-                ext = f"{self._lsuffix}{ext}"
+                ext = f" {self._lsuffix}{ext}"
             name = name[: 255 - len(ext)]
             file_ = f"{name}{ext}"
         elif self._lsuffix:
             name, ext = ospath.splitext(file_)
-            file_ = f"{name}{self._lsuffix}{ext}"
+            file_ = f"{name} {self._lsuffix}{ext}"
 
         if pre_file_ != file_:
             new_path = ospath.join(dirpath, file_)

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -106,6 +106,7 @@ class Mirror(TaskListener):
             "-e": False,
             "-z": False,
             "-sv": False,
+            "-mv": False,
             "-ss": False,
             "-f": False,
             "-fd": False,
@@ -169,6 +170,7 @@ class Mirror(TaskListener):
         self.thumb = args["-t"]
         self.split_size = args["-sp"]
         self.sample_video = args["-sv"]
+        self.merge_video = args["-mv"]
         self.screen_shots = args["-ss"]
         self.force_run = args["-f"]
         self.force_download = args["-fd"]

--- a/bot/modules/uphoster.py
+++ b/bot/modules/uphoster.py
@@ -97,6 +97,7 @@ class Uphoster(TaskListener):
             "-e": False,
             "-z": False,
             "-sv": False,
+            "-mv": False,
             "-ss": False,
             "-f": False,
             "-fd": False,
@@ -160,6 +161,7 @@ class Uphoster(TaskListener):
         self.thumb = args["-t"]
         self.split_size = args["-sp"]
         self.sample_video = args["-sv"]
+        self.merge_video = args["-mv"]
         self.screen_shots = args["-ss"]
         self.force_run = args["-f"]
         self.force_download = args["-fd"]

--- a/bot/modules/users_settings.py
+++ b/bot/modules/users_settings.py
@@ -322,6 +322,7 @@ async def get_user_settings(from_user, stype="main"):
                 "HYBRID_LEECH",
                 "STOP_DUPLICATE",
                 "DEFAULT_UPLOAD",
+                "MERGE_VIDEO",
             ]
         ):
             buttons.data_button(
@@ -801,6 +802,17 @@ async def get_user_settings(from_user, stype="main"):
             )
             display_subtitle_meta = f"<code>{display_subtitle_meta}</code>"
 
+        if user_dict.get("MERGE_VIDEO", False):
+            merge_video_status = "Enabled"
+            buttons.data_button(
+                "Disable Merge Video", f"userset {user_id} tog MERGE_VIDEO f"
+            )
+        else:
+            merge_video_status = "Disabled"
+            buttons.data_button(
+                "Enable Merge Video", f"userset {user_id} tog MERGE_VIDEO t"
+            )
+
         buttons.data_button("Back", f"userset {user_id} back", "footer")
         buttons.data_button("Close", f"userset {user_id} close", "footer")
         btns = buttons.build_menu(2)
@@ -813,7 +825,8 @@ async def get_user_settings(from_user, stype="main"):
 ┠ <b>Default Metadata</b> → {display_meta_val}
 ┠ <b>Audio Metadata</b> → {display_audio_meta}
 ┠ <b>Video Metadata</b> → {display_video_meta}
-┖ <b>Subtitle Metadata</b> → {display_subtitle_meta}"""
+┠ <b>Subtitle Metadata</b> → {display_subtitle_meta}
+┖ <b>Merge Video</b> → <b>{merge_video_status}</b>"""
 
     elif stype == "advanced":
         buttons.data_button(
@@ -1326,6 +1339,8 @@ async def edit_user_settings(client, query):
             back_to = "gdrive"
         elif data[3] in ["USER_TOKENS", "USE_DEFAULT_COOKIE"]:
             back_to = "general"
+        elif data[3] == "MERGE_VIDEO":
+            back_to = "ffset"
         else:
             back_to = "leech"
         await update_user_settings(query, stype=back_to)

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -303,6 +303,7 @@ class YtDlp(TaskListener):
             "-b": False,
             "-z": False,
             "-sv": False,
+            "-mv": False,
             "-ss": False,
             "-f": False,
             "-fd": False,
@@ -363,6 +364,7 @@ class YtDlp(TaskListener):
         self.thumb = args["-t"]
         self.split_size = args["-sp"]
         self.sample_video = args["-sv"]
+        self.merge_video = args["-mv"]
         self.screen_shots = args["-ss"]
         self.force_run = args["-f"]
         self.force_download = args["-fd"]


### PR DESCRIPTION
- Command is 
1. With Args: /l -i 5 -m citadel -mv this filename after -m will be directly used as the filename, so no need for -n, and don't include extension like .mkv in that
2. Without Args: Turn on Enable Merge Video from usetting->ffmedia setting and give command /l -i 5 -m citadel

- Fixed Prefix Suffix Spacing Issue

## Summary by Sourcery

Add optional video merging step that concatenates multiple downloaded videos in a folder into a single MKV before upload, with user-configurable toggles and status reporting.

New Features:
- Introduce -mv command flag and per-user MERGE_VIDEO setting to enable automatic merging of multiple videos into a single MKV file after download.
- Add MergeVideos utility to perform ffmpeg-based concatenation of folder video contents with progress, speed, and ETA tracking.
- Expose merge video capability in help messages and task status views, including a new Merging status type.

Enhancements:
- Adjust leech filename prefix/suffix handling to insert spaces and trim whitespace for cleaner generated filenames and captions.
- Wire merge-video behavior into the task lifecycle so it runs after file joining but before extraction and upload processing.