### PR TITLE
fix: use send_cached_media to avoid entity serialization bug

### DIFF
--- a/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/upload_utils/telegram_uploader.py
@@ -318,8 +318,10 @@ class TelegramUploader:
                 self._msgs_dict[m.link] = m.caption
         self._sent_msg = msgs_list[-1]
 
-    async def _send_cached(self, chat_id):
+    async def _send_cached(self, chat_id, reply_to_message_id=None):
         msg, kw = self._sent_msg, {"chat_id": chat_id, "disable_notification": True}
+        if reply_to_message_id:
+            kw["reply_to_message_id"] = reply_to_message_id
         cap = msg.caption or ""
         if msg.photo:
             return await TgClient.bot.send_photo(photo=msg.photo.file_id, caption=cap, **kw)
@@ -335,15 +337,19 @@ class TelegramUploader:
             return await TgClient.bot.send_video_note(video_note=msg.video_note.file_id, **kw)
         if msg.sticker:
             return await TgClient.bot.send_sticker(sticker=msg.sticker.file_id, **kw)
-        doc = msg.document
-        return await TgClient.bot.send_document(
-            document=doc.file_id if doc else msg.message_id, caption=cap, **kw
-        )
+        if msg.document:
+            return await TgClient.bot.send_document(document=msg.document.file_id, caption=cap, **kw)
+        LOGGER.warning(f"No supported media in message {msg.id} to resend")
 
     async def _copy_media(self):
         try:
             if self._bot_pm:
-                await self._send_cached(self._listener.user_id)
+                await self._send_cached(
+                    self._listener.user_id,
+                    reply_to_message_id=(
+                        self._listener.pm_msg.id if self._listener.pm_msg else None
+                    ),
+                )
         except Exception as err:
             if not self._listener.is_cancelled:
                 LOGGER.error(f"Failed To Send in BotPM:\n{str(err)}")
@@ -616,7 +622,6 @@ class TelegramUploader:
                                 leech_dest, _ = str(leech_dest).split("|", 1)
                             if leech_dest.lstrip("-").isdigit():
                                 leech_dest = int(leech_dest)
-                        await self._send_cached(leech_dest)
                         await self._send_cached(leech_dest)
                     except Exception as e:
                         if not self._listener.is_cancelled:


### PR DESCRIPTION
## Summary by Sourcery

Fix media re-sending by using cached file IDs and clean up duplicate sends.

Bug Fixes:
- Ensure cached media is resent using file IDs instead of relying on entity serialization, avoiding serialization-related failures.

Enhancements:
- Allow cached media resends to optionally reply to a specific message when sending to bot PM.
- Log a warning when attempting to resend a message that does not contain supported media instead of falling back to an unsupported path.
- Remove a duplicate invocation of the cached send helper during leech destination uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cached messages in Telegram uploads are now properly threaded to the original PM command message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SilentDemonSD/WZML-X/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->