### PR TITLE
fix: DELETE_LINKS bugs

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -63,6 +63,7 @@ from ..mirror_leech_utils.upload_utils.telegram_uploader import TelegramUploader
 from ..mirror_leech_utils.youtube_utils.youtube_upload import YouTubeUpload
 from ..telegram_helper.button_build import ButtonMaker
 from ..telegram_helper.message_utils import (
+    delete_links,
     delete_message,
     delete_status,
     send_message,
@@ -577,6 +578,7 @@ class TaskListener(TaskConfig):
                 non_queued_up.remove(self.mid)
 
         await start_from_queued()
+        await delete_links(self.message)
 
     async def on_download_error(self, error, button=None, is_limit=False):
         async with task_dict_lock:
@@ -634,6 +636,7 @@ class TaskListener(TaskConfig):
             await clean_download(self.up_dir)
         if self.thumb and await aiopath.exists(self.thumb):
             await remove(self.thumb)
+        await delete_links(self.message)
 
     async def on_upload_error(self, error):
         async with task_dict_lock:
@@ -672,3 +675,4 @@ class TaskListener(TaskConfig):
             await clean_download(self.up_dir)
         if self.thumb and await aiopath.exists(self.thumb):
             await remove(self.thumb)
+        await delete_links(self.message)

--- a/bot/modules/clone.py
+++ b/bot/modules/clone.py
@@ -70,10 +70,10 @@ class Clone(TaskListener):
 
         check_msg, check_button = await pre_task_check(self.message)
         if check_msg:
-            await delete_links(self.message)
             await auto_delete_message(
                 await send_message(self.message, check_msg, check_button)
             )
+            await delete_links(self.message)
             return
 
         args = {
@@ -136,7 +136,6 @@ class Clone(TaskListener):
             return
 
         self._set_mode_engine()
-        await delete_links(self.message)
 
         await self._proceed_to_clone(sync)
 

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -90,10 +90,10 @@ class Mirror(TaskListener):
 
         check_msg, check_button = await pre_task_check(self.message)
         if check_msg:
-            await delete_links(self.message)
             await auto_delete_message(
                 await send_message(self.message, check_msg, check_button)
             )
+            await delete_links(self.message)
             return
 
         args = {
@@ -409,8 +409,6 @@ class Mirror(TaskListener):
                     await self.remove_from_same_dir()
                     await delete_links(self.message)
                     return
-
-        await delete_links(self.message)
 
         if file_ is not None:
             await TelegramDownloadHelper(self).add_download(

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -290,10 +290,10 @@ class YtDlp(TaskListener):
 
         check_msg, check_button = await pre_task_check(self.message)
         if check_msg:
-            await delete_links(self.message)
             await auto_delete_message(
                 await send_message(self.message, check_msg, check_button)
             )
+            await delete_links(self.message)
             return
 
         args = {
@@ -509,7 +509,6 @@ class YtDlp(TaskListener):
         playlist = "entries" in result
 
         ydl = YoutubeDLHelper(self)
-        await delete_links(self.message)
         await ydl.add_download(path, qual, playlist, opt)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure task-related messages and user links are cleaned up at the correct time across mirror, clone, and YTDLP flows.

Bug Fixes:
- Fix deletion of user links occurring before validation responses are sent, so users still see error or pre-check messages before their links are removed.
- Ensure user links are removed after task completion or failure in upload and download workflows to avoid leftover command messages.

Enhancements:
- Standardize when delete_links is invoked across mirror, clone, and YTDLP modules by tying it to task completion and validation outcomes rather than intermediate states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the timing of message link cleanup operations across task workflows to ensure proper sequencing with status message handling and error cleanup paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SilentDemonSD/WZML-X/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->