### PR TITLE
Switch to async pymongo (motor is deprecated now)

### DIFF
--- a/bot/helper/ext_utils/db_handler.py
+++ b/bot/helper/ext_utils/db_handler.py
@@ -2,7 +2,7 @@ from importlib import import_module
 
 from aiofiles import open as aiopen
 from aiofiles.os import path as aiopath
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 from pymongo.errors import PyMongoError
 from pymongo.server_api import ServerApi
 
@@ -21,7 +21,7 @@ class DbManager:
         try:
             if self._conn is not None:
                 await self._conn.close()
-            self._conn = AsyncIOMotorClient(
+            self._conn = AsyncMongoClient(
                 Config.DATABASE_URL, server_api=ServerApi("1")
             )
             self.db = self._conn.wzmlx

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ langcodes
 language-data
 jinja2
 lxml
-motor
 natsort
 par2cmdline-turbo
 pillow


### PR DESCRIPTION
Motor is deprecated; pymongo 4.9+ has native async support.

## Summary by Sourcery

Switch MongoDB integration to use the async client from pymongo instead of Motor and remove the Motor dependency.

Enhancements:
- Update database connection to use pymongo's AsyncMongoClient for async MongoDB access.

Build:
- Remove the deprecated Motor library from Python dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database client implementation for enhanced compatibility and reliability.
  * Streamlined project dependencies by removing unused packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SilentDemonSD/WZML-X/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->