### PR TITLE
Fix Index Link Generation for folders

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -525,6 +525,8 @@ class TaskListener(TaskConfig):
                     if INDEX_URL and self.name:
                         safe_name = rutils.quote(self.name.strip("/"))
                         share_url = f"{INDEX_URL}/{safe_name}"
+                            if mime_type == "Folder":
+                            share_url += "/"
                         buttons.url_button("⚡ Index Link", share_url)
                         if mime_type.startswith(("image", "video", "audio")):
                             share_urls = f"{share_url}?a=view"


### PR DESCRIPTION
This pull request makes a small change to the logic for generating index links in the `on_upload_complete` method. Now, when the uploaded item is a folder, a trailing slash is added to the generated share URL to ensure correct linking behavior.