### PR TITLE
refactor: deduplicate yt-dlp cookie selection logic

### DIFF
--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -7,6 +7,7 @@ from asyncio import (
 from asyncio.subprocess import PIPE
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial, wraps
+from os import path as ospath
 
 from httpx import AsyncClient
 
@@ -23,6 +24,17 @@ from .telegraph_helper import telegraph
 COMMAND_USAGE = {}
 
 THREAD_POOL = ThreadPoolExecutor(max_workers=500)
+
+DEFAULT_COOKIE_PATH = "cookies.txt"
+
+
+def get_cookie_path(user_dict):
+    if user_dict.get("USE_DEFAULT_COOKIE", False):
+        return DEFAULT_COOKIE_PATH
+    usr_cookie = user_dict.get("USER_COOKIE_FILE", "")
+    if usr_cookie and ospath.exists(usr_cookie):
+        return usr_cookie
+    return DEFAULT_COOKIE_PATH
 
 
 class SetInterval:

--- a/bot/helper/mirror_leech_utils/download_utils/yt_dlp_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/yt_dlp_download.py
@@ -7,7 +7,7 @@ from yt_dlp import YoutubeDL, DownloadError
 
 from .... import task_dict_lock, task_dict, user_data
 from ....core.config_manager import BinConfig
-from ...ext_utils.bot_utils import sync_to_async, async_to_sync
+from ...ext_utils.bot_utils import get_cookie_path, sync_to_async, async_to_sync
 from ...ext_utils.task_manager import (
     check_running_tasks,
     stop_duplicate_check,
@@ -80,13 +80,7 @@ class YoutubeDLHelper:
                 "extractor": lambda n: 3,
             },
         }
-        cookie_to_use = (
-            usr_cookie
-            if not self._listener.user_dict.get("USE_DEFAULT_COOKIE", False)
-            and (usr_cookie := self._listener.user_dict.get("USER_COOKIE_FILE", ""))
-            and ospath.exists(usr_cookie)
-            else "cookies.txt"
-        )
+        cookie_to_use = get_cookie_path(self._listener.user_dict)
         self.opts["cookiefile"] = cookie_to_use
         LOGGER.info(
             f"Using cookies.txt file: {cookie_to_use} | User ID : {self._listener.user_id}"

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -3,7 +3,6 @@ from functools import partial
 from time import time
 
 from httpx import AsyncClient
-from aiofiles.os import path as aiopath
 from yt_dlp import YoutubeDL
 from pyrogram.filters import regex, user
 from pyrogram.handlers import CallbackQueryHandler
@@ -13,6 +12,7 @@ from ..core.config_manager import Config
 from ..helper.ext_utils.bot_utils import (
     COMMAND_USAGE,
     arg_parser,
+    get_cookie_path,
     new_task,
     sync_to_async,
 )
@@ -464,13 +464,7 @@ class YtDlp(TaskListener):
 
         self._set_mode_engine()
 
-        cookie_to_use = (
-            usr_cookie
-            if not self.user_dict.get("USE_DEFAULT_COOKIE", False)
-            and (usr_cookie := self.user_dict.get("USER_COOKIE_FILE", ""))
-            and await aiopath.exists(usr_cookie)
-            else "cookies.txt"
-        )
+        cookie_to_use = get_cookie_path(self.user_dict)
         LOGGER.info(
             f"Using cookies.txt file: {cookie_to_use} | User ID : {self.user_id}"
         )


### PR DESCRIPTION
Extract get_cookie_path() into bot_utils.py, replace duplicate cookie selection in yt_dlp_download.py and ytdlp.py. Removes unused aiopath import from ytdlp.py.

## Summary by Sourcery

Deduplicate yt-dlp cookie file selection by centralizing it in a shared utility function.

Enhancements:
- Add a shared get_cookie_path helper and default cookie path constant in bot_utils for consistent yt-dlp cookie selection.
- Refactor yt_dlp_download and ytdlp modules to use the shared cookie selection helper instead of inline logic, and remove an unused import.