### PR TITLE
fix: SABnzbd infinite retry loop blocking startup

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -15,7 +15,7 @@ from .core.tg_client import TgClient
 
 
 async def main():
-    from asyncio import gather
+    from asyncio import create_task, gather
 
     from .core.startup import (
         load_configurations,
@@ -55,8 +55,8 @@ async def main():
     await gather(
         update_qb_options(),
         update_aria2_options(),
-        update_nzb_options(),
     )
+    create_task(update_nzb_options())
     from .core.jdownloader_booter import jdownloader
     from .helper.ext_utils.files_utils import clean_all
     from .helper.ext_utils.telegraph_helper import telegraph

--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -64,19 +64,21 @@ async def update_aria2_options():
 
 
 async def update_nzb_options():
-    if Config.USENET_SERVERS:
-        LOGGER.info("Get SABnzbd options from server")
-        deadline = time() + 10
-        while time() < deadline:
-            try:
-                no = (await sabnzbd_client.get_config())["config"]["misc"]
-                nzb_options.update(no)
-                return True
-            except Exception as e:
-                LOGGER.warning(f"SABnzbd config fetch failed: {e}")
-                await sleep(0.5)
-        LOGGER.error("Failed to fetch SABnzbd options within 10 seconds")
-        return False
+    try:
+        if Config.USENET_SERVERS:
+            LOGGER.info("Get SABnzbd options from server")
+            deadline = time() + 10
+            while time() < deadline:
+                try:
+                    no = (await sabnzbd_client.get_config())["config"]["misc"]
+                    nzb_options.update(no)
+                    return
+                except Exception:
+                    LOGGER.exception("SABnzbd config fetch failed")
+                    await sleep(0.5)
+            LOGGER.error("Failed to fetch SABnzbd options within 10 seconds")
+    except Exception:
+        LOGGER.exception("update_nzb_options failed")
 
 
 async def load_settings():

--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -1,6 +1,7 @@
 from asyncio import create_subprocess_exec, create_subprocess_shell, sleep
 from importlib import import_module
 from os import environ, getenv, path as ospath
+from time import time
 
 from aiofiles import open as aiopen
 from aiofiles.os import makedirs, remove, path as aiopath
@@ -65,14 +66,17 @@ async def update_aria2_options():
 async def update_nzb_options():
     if Config.USENET_SERVERS:
         LOGGER.info("Get SABnzbd options from server")
-        while True:
+        deadline = time() + 10
+        while time() < deadline:
             try:
                 no = (await sabnzbd_client.get_config())["config"]["misc"]
                 nzb_options.update(no)
-            except Exception:
+                return True
+            except Exception as e:
+                LOGGER.warning(f"SABnzbd config fetch failed: {e}")
                 await sleep(0.5)
-                continue
-            break
+        LOGGER.error("Failed to fetch SABnzbd options within 10 seconds")
+        return False
 
 
 async def load_settings():


### PR DESCRIPTION
## Summary by Sourcery

Prevent SABnzbd configuration retrieval from blocking bot startup by bounding retries and running the fetch asynchronously alongside other startup tasks.

Bug Fixes:
- Avoid infinite retry loop when fetching SABnzbd config by limiting retry duration and handling failures gracefully.

Enhancements:
- Run SABnzbd option updates in a background task so other startup operations can complete without waiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 10-second timeout for NZB configuration initialization; if the deadline is exceeded the system logs an error and continues to avoid indefinite startup blocking.
  * NZB option loading is now scheduled to run in the background during startup so the application continues its startup flow without waiting for that operation to complete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SilentDemonSD/WZML-X/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->