### PR TITLE
Switch to async pymongo

### DIFF
--- a/update.py
+++ b/update.py
@@ -11,9 +11,10 @@ from logging import (
     ERROR,
 )
 from os import path, remove, environ
-from pymongo.mongo_client import MongoClient
+from pymongo import AsyncMongoClient
 from pymongo.server_api import ServerApi
 from subprocess import run as srun, call as scall
+from asyncio import run as arun
 
 getLogger("pymongo").setLevel(ERROR)
 
@@ -69,21 +70,35 @@ if not BOT_TOKEN:
 
 BOT_ID = BOT_TOKEN.split(":", 1)[0]
 
-if DATABASE_URL := config_file.get("DATABASE_URL", "").strip():
+
+async def fetch_database_config():
+    """Fetch configuration from MongoDB."""
+    global config_file
+    DATABASE_URL = config_file.get("DATABASE_URL", "").strip()
+    if not DATABASE_URL:
+        return
+
+    conn = None
     try:
-        conn = MongoClient(DATABASE_URL, server_api=ServerApi("1"))
+        conn = AsyncMongoClient(DATABASE_URL, server_api=ServerApi("1"))
         db = conn.wzmlx
-        old_config = db.settings.deployConfig.find_one({"_id": BOT_ID}, {"_id": 0})
-        config_dict = db.settings.config.find_one({"_id": BOT_ID})
+        old_config = await db.settings.deployConfig.find_one({"_id": BOT_ID}, {"_id": 0})
+        config_dict = await db.settings.config.find_one({"_id": BOT_ID})
         if (
             old_config is not None and old_config == config_file or old_config is None
         ) and config_dict is not None:
             config_file["UPSTREAM_REPO"] = config_dict["UPSTREAM_REPO"]
             config_file["UPSTREAM_BRANCH"] = config_dict.get("UPSTREAM_BRANCH", "wzv3")
             config_file["UPDATE_PKGS"] = config_dict.get("UPDATE_PKGS", "True")
-        conn.close()
     except Exception as e:
         log_error(f"Database ERROR: {e}")
+    finally:
+        if conn:
+            await conn.close()
+
+
+if DATABASE_URL := config_file.get("DATABASE_URL", "").strip():
+    arun(fetch_database_config())
 
 UPSTREAM_REPO = config_file.get("UPSTREAM_REPO", "").strip()
 UPSTREAM_BRANCH = config_file.get("UPSTREAM_BRANCH", "").strip() or "wzv3"


### PR DESCRIPTION
## Summary by Sourcery

Switch MongoDB configuration loading in update.py to use an asynchronous client and helper, and invoke it via the async runner when a database URL is configured.

Enhancements:
- Introduce an async helper to fetch deployment and config settings from MongoDB and update the in-memory config.
- Replace the synchronous MongoClient usage with AsyncMongoClient and ensure the connection is closed asynchronously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized configuration retrieval mechanism with asynchronous operations for improved performance and responsiveness.
  * Enhanced resource management with proper cleanup of database connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SilentDemonSD/WZML-X/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->