### PR TITLE
Revert "Switch to async pymongo (motor is deprecated now)"

### DIFF
--- a/bot/helper/ext_utils/db_handler.py
+++ b/bot/helper/ext_utils/db_handler.py
@@ -2,7 +2,7 @@ from importlib import import_module
 
 from aiofiles import open as aiopen
 from aiofiles.os import path as aiopath
-from pymongo import AsyncMongoClient
+from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo.errors import PyMongoError
 from pymongo.server_api import ServerApi
 
@@ -21,7 +21,7 @@ class DbManager:
         try:
             if self._conn is not None:
                 await self._conn.close()
-            self._conn = AsyncMongoClient(
+            self._conn = AsyncIOMotorClient(
                 Config.DATABASE_URL, server_api=ServerApi("1")
             )
             self.db = self._conn.wzmlx

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ langcodes
 language-data
 jinja2
 lxml
+motor
 natsort
 par2cmdline-turbo
 pillow


### PR DESCRIPTION
Reverts SilentDemonSD/WZML-X#498

## Summary by Sourcery

Revert the previous switch to async pymongo by restoring use of Motor as the async MongoDB client and updating dependencies accordingly.

Enhancements:
- Restore AsyncIOMotorClient as the database client implementation in the DB handler.

Build:
- Add the Motor package to the Python requirements to support the restored async MongoDB client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection dependencies for async operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SilentDemonSD/WZML-X/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->