### PR TITLE
fix qbit webui password minimum length requirement

### DIFF
--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -45,9 +45,9 @@ async def update_qb_options():
         for k in list(qbit_options.keys()):
             if k.startswith("rss"):
                 del qbit_options[k]
-        qbit_options["web_ui_password"] = "admin"
+        qbit_options["web_ui_password"] = "admin123"
         await TorrentManager.qbittorrent.app.set_preferences(
-            {"web_ui_password": "admin"}
+            {"web_ui_password": "admin123"}
         )
     else:
         await TorrentManager.qbittorrent.app.set_preferences(qbit_options)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set the default qBittorrent Web UI password to a longer value so it satisfies the Web UI minimum password length constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated qBittorrent web UI authentication configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SilentDemonSD/WZML-X/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->