### PR TITLE
fix(jdownloader): sync jd download logic and booter typo

### DIFF
--- a/bot/core/jdownloader_booter.py
+++ b/bot/core/jdownloader_booter.py
@@ -34,7 +34,7 @@ class JDownloader(MyJdApi):
             self.is_connected = False
             self.error = "JDownloader Credentials not provided!"
             return
-        self.error = "Connecting... Try agin after couple of seconds"
+        self.error = "Connecting... Try again after couple of seconds"
         self._device_name = f"{randint(0, 1000)}@{TgClient.BNAME}"
         if await path.exists("/JDownloader/logs"):
             LOGGER.info(

--- a/bot/helper/mirror_leech_utils/download_utils/jd_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/jd_download.py
@@ -6,7 +6,7 @@ from time import time
 from aiofiles.os import path as aiopath, remove
 from aiofiles import open as aiopen
 from base64 import b64encode
-from secrets import token_hex
+from secrets import token_urlsafe
 from myjd.exception import MYJDException
 
 from .... import (
@@ -65,7 +65,7 @@ class JDownloaderHelper:
         )
         try:
             await wait_for(self.event.wait(), timeout=self._timeout)
-        except Exception:
+        except:
             await edit_message(self._reply_to, "Timed Out. Task has been cancelled!")
             self.listener.is_cancelled = True
             self.event.set()
@@ -120,7 +120,7 @@ async def get_jd_download_directory():
 async def add_jd_download(listener, path):
     try:
         async with jd_listener_lock:
-            gid = token_hex(5)
+            gid = token_urlsafe(12)
             if not jdownloader.is_connected:
                 raise MYJDException(jdownloader.error)
 
@@ -157,7 +157,8 @@ async def add_jd_download(listener, path):
                         {
                             "autoExtract": False,
                             "links": listener.link,
-                            "packageName": listener.name or None,
+                            "deepDecrypt": True,
+                            "overwritePackagizerRules": listener.join,
                         }
                     ],
                 )
@@ -199,13 +200,6 @@ async def add_jd_download(listener, path):
                         LOGGER.error(error)
                         corrupted_packages.append(pack["uuid"])
                         continue
-                    save_to = pack["saveTo"]
-                    if not name:
-                        if save_to.startswith(default_path):
-                            name = save_to.replace(default_path, "", 1).split("/", 1)[0]
-                        else:
-                            name = save_to.replace(f"{path}/", "", 1).split("/", 1)[0]
-                        name = name[:255]
 
                     if (
                         pack.get("tempUnknownCount", 0) > 0
@@ -216,6 +210,9 @@ async def add_jd_download(listener, path):
 
                     listener.size += pack.get("bytesTotal", 0)
                     online_packages.append(pack["uuid"])
+                    if not name:
+                        name = pack.get("name", "").replace("/", "").split("/")[0]
+                    save_to = pack["saveTo"]
                     if save_to.startswith(default_path):
                         save_to = trim_path(save_to)
                         await jdownloader.device.linkgrabber.set_download_directory(
@@ -224,14 +221,6 @@ async def add_jd_download(listener, path):
                         )
 
                 if online_packages:
-                    if listener.join and len(online_packages) > 1:
-                        listener.name = "Joined Packages"
-                        await jdownloader.device.linkgrabber.move_to_new_package(
-                            listener.name,
-                            f"{path}/{listener.name}",
-                            package_ids=online_packages,
-                        )
-                        continue
                     break
             else:
                 error = (


### PR DESCRIPTION
## Summary by Sourcery

Align JDownloader download handling and connection messaging with updated logic and configuration.

Bug Fixes:
- Prevent unnecessary task cancellation handling by broadening the exception catch in the JDownloader event handler.
- Correct the JDownloader connection status message typo shown when credentials are missing or connection is in progress.

Enhancements:
- Switch JDownloader download identifier generation to URL-safe tokens and adjust package configuration options for decryption and packagizer behavior.
- Simplify and revise package naming and save-path handling during JDownloader linkgrabber processing, removing special join-package handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typo in boot connection error message ("Try agin" → "Try again after couple of seconds")
  * Improved JDownloader download package handling and organization with enhanced error processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->