### PR TITLE
feat: colored background for buttons

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -12,6 +12,7 @@ class Config:
     BOT_MAX_TASKS = 0
     BOT_PM = False
     CMD_SUFFIX = ""
+    COLORED_BTNS = False
     DEFAULT_LANG = "en"
     DATABASE_URL = ""
     DEFAULT_UPLOAD = "rc"

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -44,22 +44,6 @@ class SetInterval:
 def _build_command_usage(help_dict, command_key):
     buttons = ButtonMaker()
     cmd_list = list(help_dict.keys())[1:]
-    temp_store = []
-    cmd_pages = [cmd_list[i : i + 10] for i in range(0, len(cmd_list), 10)]
-    for i in range(1, len(cmd_pages) + 1):
-        for name in cmd_pages[i]:
-            buttons.data_button(name, f"help {command_key} {name}")
-        buttons.data_button("Prev", f"help pre {command_key} {i - 1}")
-        buttons.data_button("Next", f"help nex {command_key} {i + 1}")
-        buttons.data_button("Close", "help close", "footer", style=ButtonStyle.DANGER)
-        temp_store.append(buttons.build_menu(2))
-    COMMAND_USAGE[command_key] = [help_dict["main"], *temp_store]
-    buttons.reset()
-
-
-def _build_command_usage(help_dict, command_key):
-    buttons = ButtonMaker()
-    cmd_list = list(help_dict.keys())[1:]
     cmd_pages = [cmd_list[i : i + 10] for i in range(0, len(cmd_list), 10)]
     temp_store = []
 

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -102,14 +102,15 @@ def bt_selection_buttons(id_):
     pin = "".join([n for n in id_ if n.isdigit()][:4])
     buttons = ButtonMaker()
     if Config.WEB_PINCODE:
-        buttons.url_button("Select Files", f"{Config.BASE_URL}/app/files?gid={id_}")
+        buttons.url_button("Select Files", f"{Config.BASE_URL}/app/files?gid={id_}", style=ButtonStyle.PRIMARY)
         buttons.data_button("Pincode", f"sel pin {gid} {pin}")
     else:
         buttons.url_button(
-            "Select Files", f"{Config.BASE_URL}/app/files?gid={id_}&pin={pin}"
+            "Select Files", f"{Config.BASE_URL}/app/files?gid={id_}&pin={pin}",
+            style=ButtonStyle.PRIMARY,
         )
-    buttons.data_button("Done Selecting", f"sel done {gid} {id_}")
-    buttons.data_button("Cancel", f"sel cancel {gid}")
+    buttons.data_button("Done Selecting", f"sel done {gid} {id_}", style=ButtonStyle.SUCCESS)
+    buttons.data_button("Cancel", f"sel cancel {gid}", style=ButtonStyle.DANGER)
     return buttons.build_menu(2)
 
 

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -4,6 +4,7 @@ from asyncio import (
     run_coroutine_threadsafe,
     sleep,
 )
+from pyrogram.enums import ButtonStyle
 from asyncio.subprocess import PIPE
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial, wraps
@@ -50,7 +51,7 @@ def _build_command_usage(help_dict, command_key):
             buttons.data_button(name, f"help {command_key} {name}")
         buttons.data_button("Prev", f"help pre {command_key} {i - 1}")
         buttons.data_button("Next", f"help nex {command_key} {i + 1}")
-        buttons.data_button("Close", "help close", "footer")
+        buttons.data_button("Close", "help close", "footer", style=ButtonStyle.DANGER)
         temp_store.append(buttons.build_menu(2))
     COMMAND_USAGE[command_key] = [help_dict["main"], *temp_store]
     buttons.reset()
@@ -70,7 +71,7 @@ def _build_command_usage(help_dict, command_key):
                 buttons.data_button("⫷", f"help pre {command_key} {i - 1}")
             if i < len(cmd_pages) - 1:
                 buttons.data_button("⫸", f"help nex {command_key} {i + 1}")
-        buttons.data_button("Close", "help close", "footer")
+        buttons.data_button("Close", "help close", "footer", style=ButtonStyle.DANGER)
         temp_store.append(buttons.build_menu(2))
         buttons.reset()
 

--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -1,5 +1,6 @@
 from asyncio import gather, iscoroutinefunction
 from html import escape
+from pyrogram.enums import ButtonStyle
 from re import findall
 from time import time
 
@@ -289,7 +290,7 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
     msg += "⌬ <b><u>Bot Stats</u></b>"
     buttons = ButtonMaker()
     if not is_user:
-        buttons.data_button("📜 TStats", f"status {sid} ov", position="header")
+        buttons.data_button("📜 TStats", f"status {sid} ov", position="header", style=ButtonStyle.PRIMARY)
     if len(tasks) > STATUS_LIMIT:
         msg += f"<b>Page:</b> {page_no}/{pages} | <b>Tasks:</b> {tasks_no} | <b>Step:</b> {page_step}\n"
         buttons.data_button("<<", f"status {sid} pre", position="header")
@@ -301,7 +302,7 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
         for label, status_value in list(STATUSES.items()):
             if status_value != status:
                 buttons.data_button(label, f"status {sid} st {status_value}")
-    buttons.data_button("♻️ Refresh", f"status {sid} ref", position="header")
+    buttons.data_button("♻️ Refresh", f"status {sid} ref", position="header", style=ButtonStyle.PRIMARY)
     button = buttons.build_menu(8)
     msg += f"\n┟ <b>CPU</b> → {cpu_percent()}% | <b>F</b> → {get_readable_file_size(disk_usage(DOWNLOAD_DIR).free)} [{round(100 - disk_usage(DOWNLOAD_DIR).percent, 1)}%]"
     msg += f"\n┖ <b>RAM</b> → {virtual_memory().percent}% | <b>UP</b> → {get_readable_time(time() - bot_start_time)}"

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -4,6 +4,7 @@ from time import time
 from mimetypes import guess_type
 from contextlib import suppress
 from os import path as ospath
+from pyrogram.enums import ButtonStyle
 
 from aiofiles.os import listdir, remove, path as aiopath
 from requests import utils as rutils
@@ -417,12 +418,12 @@ class TaskListener(TaskConfig):
                 msg += "\n┠ <b>Type</b> → Playlist"
                 msg += f"\n┖ <b>Total Videos</b> → {files}"
                 if link:
-                    buttons.url_button("🔗 View Playlist", link)
+                    buttons.url_button("🔗 View Playlist", link, style=ButtonStyle.PRIMARY)
                 user_message = f"{self.tag}\nYour playlist ({files} videos) has been uploaded to YouTube successfully!"
             else:
                 msg += "\n┖ <b>Type</b> → Video"
                 if link:
-                    buttons.url_button("🔗 View Video", link)
+                    buttons.url_button("🔗 View Video", link, style=ButtonStyle.PRIMARY)
                 user_message = (
                     f"{self.tag}\nYour video has been uploaded to YouTube successfully!"
                 )
@@ -503,7 +504,7 @@ class TaskListener(TaskConfig):
             ):
                 buttons = ButtonMaker()
                 if link and Config.SHOW_CLOUD_LINK:
-                    buttons.url_button("☁️ Cloud Link", link)
+                    buttons.url_button("☁️ Cloud Link", link, style=ButtonStyle.PRIMARY)
                 elif multi_links:
                     for name, url in multi_links:
                         buttons.url_button(name, url)
@@ -515,7 +516,7 @@ class TaskListener(TaskConfig):
                     share_url = f"{Config.RCLONE_SERVE_URL}/{remote}/{url_path}"
                     if mime_type == "Folder":
                         share_url += "/"
-                    buttons.url_button("🔗 Rclone Link", share_url)
+                    buttons.url_button("🔗 Rclone Link", share_url, style=ButtonStyle.PRIMARY)
                 if not rclone_path and dir_id:
                     INDEX_URL = ""
                     if self.private_link:
@@ -527,10 +528,10 @@ class TaskListener(TaskConfig):
                         share_url = f"{INDEX_URL}/{safe_name}"
                         if mime_type == "Folder":
                             share_url += "/"
-                        buttons.url_button("⚡ Index Link", share_url)
+                        buttons.url_button("⚡ Index Link", share_url, style=ButtonStyle.PRIMARY)
                         if mime_type.startswith(("image", "video", "audio")):
                             share_urls = f"{share_url}?a=view"
-                            buttons.url_button("🌐 View Link", share_urls)
+                            buttons.url_button("🌐 View Link", share_urls, style=ButtonStyle.PRIMARY)
                 button = buttons.build_menu(2)
             else:
                 if not multi_link_msg:

--- a/bot/helper/mirror_leech_utils/download_utils/jd_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/jd_download.py
@@ -1,5 +1,6 @@
 from asyncio import wait_for, Event, sleep
 from functools import partial
+from pyrogram.enums import ButtonStyle
 from pyrogram.filters import regex, user
 from pyrogram.handlers import CallbackQueryHandler
 from time import time
@@ -75,8 +76,8 @@ class JDownloaderHelper:
     async def wait_for_configurations(self):
         buttons = ButtonMaker()
         buttons.url_button("Select", "https://my.jdownloader.org")
-        buttons.data_button("Done Selecting", "jdq sdone")
-        buttons.data_button("Cancel", "jdq cancel")
+        buttons.data_button("Done Selecting", "jdq sdone", style=ButtonStyle.SUCCESS)
+        buttons.data_button("Cancel", "jdq cancel", style=ButtonStyle.DANGER)
         button = buttons.build_menu(2)
         msg = f"Remove the unwanted files or change variants or edit files names from myJdownloader site for <b>{self.listener.name}</b>.\nDon't start it manually!\n\nAfter finish press Done Selecting!\nTimeout: 10 min"
         self._reply_to = await send_message(self.listener.message, msg, button)

--- a/bot/helper/mirror_leech_utils/gdrive_utils/list.py
+++ b/bot/helper/mirror_leech_utils/gdrive_utils/list.py
@@ -4,6 +4,7 @@ from functools import partial
 from logging import getLogger
 from natsort import natsorted
 from pyrogram.filters import regex, user
+from pyrogram.enums import ButtonStyle
 from pyrogram.handlers import CallbackQueryHandler
 from tenacity import RetryError
 from time import time
@@ -190,9 +191,9 @@ class GoogleDriveList(GoogleDriveHelper):
             else:
                 buttons.data_button("Folders", "gdq itype folders", position="footer")
         if self.list_status == "gdu" or len(self.items_list) > 0:
-            buttons.data_button("Choose Current Path", "gdq cur", position="footer")
+            buttons.data_button("Choose Current Path", "gdq cur", position="footer", style=ButtonStyle.SUCCESS)
         if self.list_status == "gdu":
-            buttons.data_button("Set as Default Path", "gdq def", position="footer")
+            buttons.data_button("Set as Default Path", "gdq def", position="footer", style=ButtonStyle.SUCCESS)
         if (
             len(self.parents) > 1
             and len(self.drives) > 1
@@ -201,8 +202,8 @@ class GoogleDriveList(GoogleDriveHelper):
         ):
             buttons.data_button("Back", "gdq back pa", position="footer")
         if len(self.parents) > 1:
-            buttons.data_button("Back To Root", "gdq root", position="footer")
-        buttons.data_button("Cancel", "gdq cancel", position="footer")
+            buttons.data_button("Back To Root", "gdq root", position="footer", style=ButtonStyle.SUCCESS)
+        buttons.data_button("Cancel", "gdq cancel", position="footer", style=ButtonStyle.DANGER)
         button = buttons.build_menu(f_cols=2)
         msg = "Choose Path:" + (
             "\nTransfer Type: <i>Download</i>"
@@ -265,7 +266,7 @@ class GoogleDriveList(GoogleDriveHelper):
             buttons = ButtonMaker()
             if self._token_user and self._token_owner:
                 buttons.data_button("Back", "gdq back dr", position="footer")
-            buttons.data_button("Cancel", "gdq cancel", position="footer")
+            buttons.data_button("Cancel", "gdq cancel", position="footer", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             await self._send_list_message(msg, button)
         elif self.use_sa and len(drives) == 1:
@@ -294,7 +295,7 @@ class GoogleDriveList(GoogleDriveHelper):
                 buttons.data_button(item["name"], f"gdq dr {index}")
             if self._token_user and self._token_owner:
                 buttons.data_button("Back", "gdq back dr", position="footer")
-            buttons.data_button("Cancel", "gdq cancel", position="footer")
+            buttons.data_button("Cancel", "gdq cancel", position="footer", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             await self._send_list_message(msg, button)
 
@@ -322,7 +323,7 @@ class GoogleDriveList(GoogleDriveHelper):
                 buttons.data_button("Service Accounts", "gdq sa")
             if self._token_user:
                 buttons.data_button("My Token", "gdq user")
-            buttons.data_button("Cancel", "gdq cancel")
+            buttons.data_button("Cancel", "gdq cancel", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             await self._send_list_message(msg, button)
         else:

--- a/bot/helper/mirror_leech_utils/rclone_utils/list.py
+++ b/bot/helper/mirror_leech_utils/rclone_utils/list.py
@@ -5,6 +5,7 @@ from configparser import RawConfigParser
 from functools import partial
 from json import loads
 from pyrogram.filters import regex, user
+from pyrogram.enums import ButtonStyle
 from pyrogram.handlers import CallbackQueryHandler
 from time import time
 
@@ -218,7 +219,7 @@ class RcloneList:
                     "Folders", "rcq itype --dirs-only", position="footer"
                 )
         if self.list_status == "rcu" or len(self.path_list) > 0:
-            buttons.data_button("Choose Current Path", "rcq cur", position="footer")
+            buttons.data_button("Choose Current Path", "rcq cur", position="footer", style=ButtonStyle.SUCCESS)
         if self.list_status == "rcd":
             buttons.data_button(
                 f"Select: {'Enabled' if self.select else 'Disabled'}",
@@ -226,15 +227,15 @@ class RcloneList:
                 position="footer",
             )
         if len(self.selected_pathes) > 1:
-            buttons.data_button("Done With Selection", "rcq ds", position="footer")
+            buttons.data_button("Done With Selection", "rcq ds", position="footer", style=ButtonStyle.SUCCESS)
             buttons.data_button("Clear Selection", "rcq clear", position="footer")
         if self.list_status == "rcu":
-            buttons.data_button("Set as Default Path", "rcq def", position="footer")
+            buttons.data_button("Set as Default Path", "rcq def", position="footer", style=ButtonStyle.SUCCESS)
         if self.path or len(self._sections) > 1 or self._rc_user and self._rc_owner:
             buttons.data_button("Back", "rcq back pa", position="footer")
         if self.path:
-            buttons.data_button("Back To Root", "rcq root", position="footer")
-        buttons.data_button("Cancel", "rcq cancel", position="footer")
+            buttons.data_button("Back To Root", "rcq root", position="footer", style=ButtonStyle.SUCCESS)
+        buttons.data_button("Cancel", "rcq cancel", position="footer", style=ButtonStyle.DANGER)
         button = buttons.build_menu(f_cols=2)
         msg = "Choose Path:" + (
             "\nTransfer Type: <i>Download</i>"
@@ -323,7 +324,7 @@ class RcloneList:
                 buttons.data_button(remote, f"rcq re {remote}:")
             if self._rc_user and self._rc_owner:
                 buttons.data_button("Back", "rcq back re", position="footer")
-            buttons.data_button("Cancel", "rcq cancel", position="footer")
+            buttons.data_button("Cancel", "rcq cancel", position="footer", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             await self._send_list_message(msg, button)
 
@@ -340,7 +341,7 @@ class RcloneList:
             buttons = ButtonMaker()
             buttons.data_button("Owner Config", "rcq owner")
             buttons.data_button("My Config", "rcq user")
-            buttons.data_button("Cancel", "rcq cancel")
+            buttons.data_button("Cancel", "rcq cancel", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             await self._send_list_message(msg, button)
         else:

--- a/bot/helper/telegram_helper/button_build.py
+++ b/bot/helper/telegram_helper/button_build.py
@@ -1,6 +1,14 @@
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from pyrogram.enums import ButtonStyle
 
+from ...core.config_manager import Config
+
+
+def _btn_style(style=None):
+    if Config.COLORED_BTNS and style:
+        return style
+    return ButtonStyle.DEFAULT
+
 
 class ButtonMaker:
     def __init__(self):
@@ -14,12 +22,12 @@ class ButtonMaker:
 
     def url_button(self, key, link, position=None, style=None):
         self.buttons[position if position in self.buttons else "default"].append(
-            InlineKeyboardButton(text=key, url=link, style=style or ButtonStyle.DEFAULT)
+            InlineKeyboardButton(text=key, url=link, style=_btn_style(style))
         )
 
     def data_button(self, key, data, position=None, style=None):
         self.buttons[position if position in self.buttons else "default"].append(
-            InlineKeyboardButton(text=key, callback_data=data, style=style or ButtonStyle.DEFAULT)
+            InlineKeyboardButton(text=key, callback_data=data, style=_btn_style(style))
         )
 
     def build_menu(self, b_cols=1, h_cols=8, fb_cols=2, lb_cols=2, f_cols=8):

--- a/bot/helper/telegram_helper/button_build.py
+++ b/bot/helper/telegram_helper/button_build.py
@@ -1,4 +1,5 @@
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from pyrogram.enums import ButtonStyle
 
 
 class ButtonMaker:
@@ -11,14 +12,14 @@ class ButtonMaker:
             "footer": [],
         }
 
-    def url_button(self, key, link, position=None):
+    def url_button(self, key, link, position=None, style=None):
         self.buttons[position if position in self.buttons else "default"].append(
-            InlineKeyboardButton(text=key, url=link)
+            InlineKeyboardButton(text=key, url=link, style=style or ButtonStyle.DEFAULT)
         )
 
-    def data_button(self, key, data, position=None):
+    def data_button(self, key, data, position=None, style=None):
         self.buttons[position if position in self.buttons else "default"].append(
-            InlineKeyboardButton(text=key, callback_data=data)
+            InlineKeyboardButton(text=key, callback_data=data, style=style or ButtonStyle.DEFAULT)
         )
 
     def build_menu(self, b_cols=1, h_cols=8, fb_cols=2, lb_cols=2, f_cols=8):

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -78,12 +78,12 @@ DEFAULT_VALUES = {
 async def get_buttons(key=None, edit_type=None, edit_mode=False):
     buttons = ButtonMaker()
     if key is None:
-        buttons.data_button("Config Variables", "botset var", style=ButtonStyle.PRIMARY)
-        buttons.data_button("Private Files", "botset private open", style=ButtonStyle.PRIMARY)
-        buttons.data_button("Qbit Settings", "botset qbit", style=ButtonStyle.PRIMARY)
-        buttons.data_button("Aria2c Settings", "botset aria", style=ButtonStyle.PRIMARY)
-        buttons.data_button("Sabnzbd Settings", "botset nzb", style=ButtonStyle.PRIMARY)
-        buttons.data_button("JDownloader Sync", "botset syncjd", style=ButtonStyle.PRIMARY)
+        buttons.data_button("Config Variables", "botset var")
+        buttons.data_button("Private Files", "botset private open")
+        buttons.data_button("Qbit Settings", "botset qbit")
+        buttons.data_button("Aria2c Settings", "botset aria")
+        buttons.data_button("Sabnzbd Settings", "botset nzb")
+        buttons.data_button("JDownloader Sync", "botset syncjd")
         buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         msg = "Bot Settings:"
     elif edit_type is not None:

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -78,12 +78,12 @@ DEFAULT_VALUES = {
 async def get_buttons(key=None, edit_type=None, edit_mode=False):
     buttons = ButtonMaker()
     if key is None:
-        buttons.data_button("Config Variables", "botset var")
-        buttons.data_button("Private Files", "botset private open")
-        buttons.data_button("Qbit Settings", "botset qbit")
-        buttons.data_button("Aria2c Settings", "botset aria")
-        buttons.data_button("Sabnzbd Settings", "botset nzb")
-        buttons.data_button("JDownloader Sync", "botset syncjd")
+        buttons.data_button("Config Variables", "botset var", style=ButtonStyle.PRIMARY)
+        buttons.data_button("Private Files", "botset private open", style=ButtonStyle.PRIMARY)
+        buttons.data_button("Qbit Settings", "botset qbit", style=ButtonStyle.PRIMARY)
+        buttons.data_button("Aria2c Settings", "botset aria", style=ButtonStyle.PRIMARY)
+        buttons.data_button("Sabnzbd Settings", "botset nzb", style=ButtonStyle.PRIMARY)
+        buttons.data_button("JDownloader Sync", "botset syncjd", style=ButtonStyle.PRIMARY)
         buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         msg = "Bot Settings:"
     elif edit_type is not None:
@@ -142,9 +142,9 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
                 continue
             buttons.data_button(k, f"botset botvar {k}")
         if state == "view":
-            buttons.data_button("Edit", "botset edit var")
+            buttons.data_button("Edit", "botset edit var", style=ButtonStyle.PRIMARY)
         else:
-            buttons.data_button("View", "botset view var")
+            buttons.data_button("View", "botset view var", style=ButtonStyle.PRIMARY)
         buttons.data_button("Back", "botset back")
         buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         for x in range(0, len(conf_dict), 10):

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -4,6 +4,7 @@ from asyncio import (
     gather,
     sleep,
 )
+from pyrogram.enums import ButtonStyle
 from functools import partial
 from io import BytesIO
 from os import getcwd
@@ -83,7 +84,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
         buttons.data_button("Aria2c Settings", "botset aria")
         buttons.data_button("Sabnzbd Settings", "botset nzb")
         buttons.data_button("JDownloader Sync", "botset syncjd")
-        buttons.data_button("Close", "botset close")
+        buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         msg = "Bot Settings:"
     elif edit_type is not None:
         if edit_type == "botvar":
@@ -91,7 +92,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
             buttons.data_button("Back", "botset var")
             if key not in ["TELEGRAM_HASH", "TELEGRAM_API", "OWNER_ID", "BOT_TOKEN"]:
                 buttons.data_button("Default", f"botset resetvar {key}")
-            buttons.data_button("Close", "botset close")
+            buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
             if key in [
                 "CMD_SUFFIX",
                 "OWNER_ID",
@@ -107,7 +108,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
             buttons.data_button("Back", "botset aria")
             if key != "newkey":
                 buttons.data_button("Empty String", f"botset emptyaria {key}")
-            buttons.data_button("Close", "botset close")
+            buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
             msg = (
                 "Send a key with value. Example: https-proxy-user:value. Timeout: 60 sec"
                 if key == "newkey"
@@ -116,20 +117,20 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
         elif edit_type == "qbitvar":
             buttons.data_button("Back", "botset qbit")
             buttons.data_button("Empty String", f"botset emptyqbit {key}")
-            buttons.data_button("Close", "botset close")
+            buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
             msg = f"Send a valid value for {key}. Current value is '{qbit_options[key]}'. Timeout: 60 sec"
         elif edit_type == "nzbvar":
             buttons.data_button("Back", "botset nzb")
             buttons.data_button("Default", f"botset resetnzb {key}")
             buttons.data_button("Empty String", f"botset emptynzb {key}")
-            buttons.data_button("Close", "botset close")
+            buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
             msg = f"Send a valid value for {key}. Current value is '{nzb_options[key]}'.\nIf the value is list then seperate them by space or ,\nExample: .exe,info or .exe .info\nTimeout: 60 sec"
         elif edit_type.startswith("nzbsevar"):
             index = 0 if key == "newser" else int(edit_type.replace("nzbsevar", ""))
             buttons.data_button("Back", f"botset nzbser{index}")
             if key != "newser":
                 buttons.data_button("Empty", f"botset emptyserkey {index} {key}")
-            buttons.data_button("Close", "botset close")
+            buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
             if key == "newser":
                 msg = "Send one server as dictionary {}, like in config.py without []. Timeout: 60 sec"
             else:
@@ -145,7 +146,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
         else:
             buttons.data_button("View", "botset view var")
         buttons.data_button("Back", "botset back")
-        buttons.data_button("Close", "botset close")
+        buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         for x in range(0, len(conf_dict), 10):
             buttons.data_button(
                 f"{int(x / 10)}", f"botset start var {x}", position="footer"
@@ -158,7 +159,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
             buttons.data_button("Create New File", "botset private new")
             buttons.data_button("Add/Delete File", "botset private edit")
         buttons.data_button("Back", "botset back", position="footer")
-        buttons.data_button("Close", "botset close", position="footer")
+        buttons.data_button("Close", "botset close", position="footer", style=ButtonStyle.DANGER)
         txt = "\n┠ ".join(
             [
                 f"<code>{fn}</code> → <b>{'Exists' if await aiopath.isfile(fn) else 'Not Exists'}</b>"
@@ -194,7 +195,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
             buttons.data_button("View", "botset view aria")
         buttons.data_button("Add new key", "botset ariavar newkey")
         buttons.data_button("Back", "botset back")
-        buttons.data_button("Close", "botset close")
+        buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         for x in range(0, len(aria2_options), 10):
             buttons.data_button(
                 f"{int(x / 10)}", f"botset start aria {x}", position="footer"
@@ -209,7 +210,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
             buttons.data_button("View", "botset view qbit")
         buttons.data_button("Sync Qbittorrent", "botset syncqbit")
         buttons.data_button("Back", "botset back")
-        buttons.data_button("Close", "botset close")
+        buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         for x in range(0, len(qbit_options), 10):
             buttons.data_button(
                 f"{int(x / 10)}", f"botset start qbit {x}", position="footer"
@@ -225,7 +226,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
         buttons.data_button("Servers", "botset nzbserver")
         buttons.data_button("Sync Sabnzbd", "botset syncnzb")
         buttons.data_button("Back", "botset back")
-        buttons.data_button("Close", "botset close")
+        buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         for x in range(0, len(nzb_options), 10):
             buttons.data_button(
                 f"{int(x / 10)}", f"botset start nzb {x}", position="footer"
@@ -237,7 +238,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
                 buttons.data_button(k["name"], f"botset nzbser{index}")
         buttons.data_button("Add New", "botset nzbsevar newser")
         buttons.data_button("Back", "botset nzb")
-        buttons.data_button("Close", "botset close")
+        buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         if len(Config.USENET_SERVERS) > 10:
             for x in range(0, len(Config.USENET_SERVERS), 10):
                 buttons.data_button(
@@ -257,7 +258,7 @@ async def get_buttons(key=None, edit_type=None, edit_mode=False):
             buttons.data_button("View", f"botset view {key}")
         buttons.data_button("Remove Server", f"botset remser {index}")
         buttons.data_button("Back", "botset nzbserver")
-        buttons.data_button("Close", "botset close")
+        buttons.data_button("Close", "botset close", style=ButtonStyle.DANGER)
         if len(Config.USENET_SERVERS[index].keys()) > 10:
             for x in range(0, len(Config.USENET_SERVERS[index]), 10):
                 buttons.data_button(
@@ -553,7 +554,7 @@ async def update_private_file(_, message, pre_message, key, new_file=False):
             buttons = ButtonMaker()
             msg = "Push to UPSTREAM_REPO ?"
             buttons.data_button("Yes!", f"botset push {file_name}")
-            buttons.data_button("No", "botset close")
+            buttons.data_button("No", "botset close", style=ButtonStyle.DANGER)
             await send_message(message, msg, buttons.build_menu(2))
         else:
             await delete_message(message)

--- a/bot/modules/cancel_task.py
+++ b/bot/modules/cancel_task.py
@@ -1,4 +1,5 @@
 from asyncio import sleep
+from pyrogram.enums import ButtonStyle
 
 from .. import task_dict, task_dict_lock, user_data, multi_tags
 from ..core.tg_client import Config
@@ -126,7 +127,7 @@ def create_cancel_buttons(is_sudo, user_id=""):
             buttons.data_button("All Added Tasks", f"canall bot ms {user_id}")
         else:
             buttons.data_button("My Tasks", f"canall user ms {user_id}")
-    buttons.data_button("Close", f"canall close ms {user_id}")
+    buttons.data_button("Close", f"canall close ms {user_id}", style=ButtonStyle.DANGER)
     return buttons.build_menu(2)
 
 
@@ -169,7 +170,7 @@ async def cancel_all_update(_, query):
         buttons = button_build.ButtonMaker()
         buttons.data_button("Yes!", f"canall {data[2]} confirm {user_id}")
         buttons.data_button("Back", f"canall back confirm {user_id}")
-        buttons.data_button("Close", f"canall close confirm {user_id}")
+        buttons.data_button("Close", f"canall close confirm {user_id}", style=ButtonStyle.DANGER)
         button = buttons.build_menu(2)
         await edit_message(
             message, f"Are you sure you want to cancel all {data[2]} tasks", button

--- a/bot/modules/imdb.py
+++ b/bot/modules/imdb.py
@@ -272,10 +272,10 @@ async def imdb_callback(_, query):
         buttons = ButtonMaker()
         if imdb["trailer"]:
             if isinstance(imdb["trailer"], list):
-                buttons.url_button("▶️ IMDb Trailer ", imdb["trailer"][-1])
+                buttons.url_button("▶️ IMDb Trailer ", imdb["trailer"][-1], style=ButtonStyle.PRIMARY)
                 imdb["trailer"] = list_to_str(imdb["trailer"])
             else:
-                buttons.url_button("▶️ IMDb Trailer ", imdb["trailer"])
+                buttons.url_button("▶️ IMDb Trailer ", imdb["trailer"], style=ButtonStyle.PRIMARY)
         buttons.data_button("🚫 Close 🚫", f"imdb {user_id} close", style=ButtonStyle.DANGER)
         buttons = buttons.build_menu(1)
         template = ""

--- a/bot/modules/imdb.py
+++ b/bot/modules/imdb.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+from pyrogram.enums import ButtonStyle
 from re import IGNORECASE, findall, search
 
 import cloudscraper
@@ -76,7 +77,7 @@ async def imdb_search(_, message):
                     f"🎬 {movie.title} ({getattr(movie , 'year' , 'N/A')})",
                     f"imdb {user_id} movie {movie.id}",
                 )
-        buttons.data_button("🚫 Close 🚫", f"imdb {user_id} close")
+        buttons.data_button("🚫 Close 🚫", f"imdb {user_id} close", style=ButtonStyle.DANGER)
         await edit_message(
             k, "<b><i>Search Results found on IMDb.com</i></b>", buttons.build_menu(1)
         )
@@ -275,7 +276,7 @@ async def imdb_callback(_, query):
                 imdb["trailer"] = list_to_str(imdb["trailer"])
             else:
                 buttons.url_button("▶️ IMDb Trailer ", imdb["trailer"])
-        buttons.data_button("🚫 Close 🚫", f"imdb {user_id} close")
+        buttons.data_button("🚫 Close 🚫", f"imdb {user_id} close", style=ButtonStyle.DANGER)
         buttons = buttons.build_menu(1)
         template = ""
         # if int(data[1]) in user_data and user_data[int(data[1])].get('imdb_temp'):

--- a/bot/modules/plugin_manager.py
+++ b/bot/modules/plugin_manager.py
@@ -1,4 +1,5 @@
 from pyrogram import Client
+from pyrogram.enums import ButtonStyle
 from pyrogram.filters import command, regex
 from pyrogram.handlers import CallbackQueryHandler, MessageHandler
 from pyrogram.types import Message
@@ -28,7 +29,7 @@ async def get_plugins_menu(user_id: int, stype: str = "main"):
         )
         buttons.data_button("Available Plugins", f"plugins {user_id} available")
         buttons.data_button("Plugin Info", f"plugins {user_id} info")
-        buttons.data_button("Close", f"plugins {user_id} close", position="footer")
+        buttons.data_button("Close", f"plugins {user_id} close", position="footer", style=ButtonStyle.DANGER)
 
         text = f"""⌬ <b>Plugin Management</b>
 │
@@ -48,7 +49,7 @@ async def get_plugins_menu(user_id: int, stype: str = "main"):
             )
 
         buttons.data_button("Back", f"plugins {user_id} main", position="footer")
-        buttons.data_button("Close", f"plugins {user_id} close", position="footer")
+        buttons.data_button("Close", f"plugins {user_id} close", position="footer", style=ButtonStyle.DANGER)
 
         text = f"""⌬ <b>Loaded Plugins</b>
 │
@@ -65,7 +66,7 @@ async def get_plugins_menu(user_id: int, stype: str = "main"):
                 buttons.data_button(f"📦 {plugin}", f"plugins {user_id} load {plugin}")
 
         buttons.data_button("Back", f"plugins {user_id} main", position="footer")
-        buttons.data_button("Close", f"plugins {user_id} close", position="footer")
+        buttons.data_button("Close", f"plugins {user_id} close", position="footer", style=ButtonStyle.DANGER)
 
         unloaded_count = len([p for p in available_plugins if p not in loaded_plugins])
         text = f"""⌬ <b>Available Plugins</b>
@@ -87,7 +88,7 @@ async def get_plugins_menu(user_id: int, stype: str = "main"):
             text += f"┖ Description: {plugin.description}\n\n"
 
         buttons.data_button("Back", f"plugins {user_id} main", position="footer")
-        buttons.data_button("Close", f"plugins {user_id} close", position="footer")
+        buttons.data_button("Close", f"plugins {user_id} close", position="footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
     elif stype.startswith("plugin_"):
@@ -104,7 +105,7 @@ async def get_plugins_menu(user_id: int, stype: str = "main"):
             buttons.data_button("Reload", f"plugins {user_id} reload {plugin_name}")
 
             buttons.data_button("Back", f"plugins {user_id} loaded", position="footer")
-            buttons.data_button("Close", f"plugins {user_id} close", position="footer")
+            buttons.data_button("Close", f"plugins {user_id} close", position="footer", style=ButtonStyle.DANGER)
 
             text = f"""⌬ <b>Plugin: {plugin_name}</b>
 │

--- a/bot/modules/rss.py
+++ b/bot/modules/rss.py
@@ -1,4 +1,5 @@
 from httpx import AsyncClient
+from pyrogram.enums import ButtonStyle
 from apscheduler.triggers.interval import IntervalTrigger
 from asyncio import Lock, sleep
 from datetime import datetime, timedelta
@@ -148,7 +149,7 @@ async def rss_menu(event):
             buttons.data_button("Shutdown Rss", f"rss shutdown {user_id}")
         else:
             buttons.data_button("Start Rss", f"rss start {user_id}")
-    buttons.data_button("Close", f"rss close {user_id}")
+    buttons.data_button("Close", f"rss close {user_id}", style=ButtonStyle.DANGER)
     button = buttons.build_menu(2)
     if chat := Config.RSS_CHAT:
         if isinstance(chat, int):
@@ -424,7 +425,7 @@ async def rss_list(query, start, all_users=False):
                 )
                 list_feed += f"<b>Paused:</b> <code>{data['paused']}</code>\n"
     buttons.data_button("Back", f"rss back {user_id}")
-    buttons.data_button("Close", f"rss close {user_id}")
+    buttons.data_button("Close", f"rss close {user_id}", style=ButtonStyle.DANGER)
     if keysCount > 5:
         for x in range(0, keysCount, 5):
             buttons.data_button(
@@ -603,7 +604,7 @@ async def rss_listener(client, query):
         handler_dict[user_id] = False
         buttons = ButtonMaker()
         buttons.data_button("Back", f"rss back {user_id}")
-        buttons.data_button("Close", f"rss close {user_id}")
+        buttons.data_button("Close", f"rss close {user_id}", style=ButtonStyle.DANGER)
         button = buttons.build_menu(2)
         await edit_message(message, RSS_HELP_MESSAGE, button)
         pfunc = partial(rss_sub, pre_event=query)
@@ -624,7 +625,7 @@ async def rss_listener(client, query):
             await query.answer()
             buttons = ButtonMaker()
             buttons.data_button("Back", f"rss back {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             await edit_message(
                 message,
@@ -647,7 +648,7 @@ async def rss_listener(client, query):
                 buttons.data_button("Resume AllMyFeeds", f"rss uallresume {user_id}")
             elif data[1] == "unsubscribe":
                 buttons.data_button("Unsub AllMyFeeds", f"rss uallunsub {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             await edit_message(
                 message,
@@ -664,7 +665,7 @@ async def rss_listener(client, query):
             await query.answer()
             buttons = ButtonMaker()
             buttons.data_button("Back", f"rss back {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             msg = """Send one or more rss titles with new filters or command separated by new line.
 Examples:
@@ -738,7 +739,7 @@ Timeout: 60 sec. Argument -c for command and arguments
             await query.answer()
             buttons = ButtonMaker()
             buttons.data_button("Back", f"rss back {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}", style=ButtonStyle.DANGER)
             button = buttons.build_menu(2)
             msg = "Send one or more user_id separated by space to delete their resources.\nTimeout: 60 sec."
             await edit_message(message, msg, button)

--- a/bot/modules/search.py
+++ b/bot/modules/search.py
@@ -1,6 +1,7 @@
 from httpx import AsyncClient
 from html import escape
 from urllib.parse import quote
+from pyrogram.enums import ButtonStyle
 
 from .. import LOGGER
 from ..core.config_manager import Config
@@ -115,7 +116,7 @@ async def search(key, site, message, method):
         await TorrentManager.qbittorrent.search.delete(search_id)
     link = await get_result(search_results, key, message, method)
     buttons = ButtonMaker()
-    buttons.url_button("🔎 VIEW", link)
+    buttons.url_button("🔎 VIEW", link, style=ButtonStyle.PRIMARY)
     button = buttons.build_menu(1)
     await edit_message(message, msg, button)
 

--- a/bot/modules/services.py
+++ b/bot/modules/services.py
@@ -249,7 +249,7 @@ async def log_cb(_, query):
         if resp.status_code == 200:
             await query.answer("Generating..")
             btn = ButtonMaker()
-            btn.url_button("📨 Web Paste (SB)", resp.url)
+            btn.url_button("📨 Web Paste (SB)", resp.url, style=ButtonStyle.PRIMARY)
             await edit_reply_markup(message, btn.build_menu(1))
         else:
             await query.answer("Web Paste Failed ! Check Logs", show_alert=True)

--- a/bot/modules/services.py
+++ b/bot/modules/services.py
@@ -1,4 +1,5 @@
 from html import escape
+from pyrogram.enums import ButtonStyle
 from time import monotonic, time
 from uuid import uuid4
 from re import match
@@ -176,7 +177,7 @@ async def log(_, message):
     buttons = ButtonMaker()
     buttons.data_button("Log Disp", f"log {uid} disp")
     buttons.data_button("Web Log", f"log {uid} web")
-    buttons.data_button("Close", f"log {uid} close")
+    buttons.data_button("Close", f"log {uid} close", style=ButtonStyle.DANGER)
     await send_file(message, "log.txt", buttons=buttons.build_menu(2))
 
 
@@ -211,7 +212,7 @@ async def log_cb(_, query):
             text = f"<b>Showing Last {len(res)} Lines from log.txt:</b> \n\n----------<b>START LOG</b>----------\n\n<blockquote expandable>{escape('\n'.join(reversed(res)))}</blockquote>\n----------<b>END LOG</b>----------"
 
             btn = ButtonMaker()
-            btn.data_button("Close", f"log {user_id} close")
+            btn.data_button("Close", f"log {user_id} close", style=ButtonStyle.DANGER)
             await send_message(message, text, btn.build_menu(1))
             await edit_reply_markup(message, None)
         except Exception as err:

--- a/bot/modules/stats.py
+++ b/bot/modules/stats.py
@@ -1,4 +1,5 @@
 from asyncio import gather, sleep, wait_for, TimeoutError
+from pyrogram.enums import ButtonStyle
 from platform import platform, version
 from re import search as research
 from time import time
@@ -229,7 +230,7 @@ async def get_stats(event, key="home"):
         btns.data_button("🔄 Refresh", f"stats {user_id} systasks", "header")
 
     btns.data_button("Back", f"stats {user_id} home", "footer")
-    btns.data_button("Close", f"stats {user_id} close", "footer")
+    btns.data_button("Close", f"stats {user_id} close", "footer", style=ButtonStyle.DANGER)
     return msg, btns.build_menu(8 if key == "systasks" else 2)
 
 

--- a/bot/modules/users_settings.py
+++ b/bot/modules/users_settings.py
@@ -1,4 +1,5 @@
 from asyncio import sleep
+from pyrogram.enums import ButtonStyle
 from functools import partial
 from html import escape
 from io import BytesIO
@@ -351,7 +352,7 @@ async def get_user_settings(from_user, stype="main"):
             buttons.data_button(
                 "Reset All", f"userset {user_id} confirm_reset_all", position="footer"
             )
-        buttons.data_button("Close", f"userset {user_id} close", position="footer")
+        buttons.data_button("Close", f"userset {user_id} close", position="footer", style=ButtonStyle.DANGER)
 
         text = f"""⌬ <b>User Settings :</b>
 │
@@ -383,7 +384,7 @@ async def get_user_settings(from_user, stype="main"):
         )
 
         buttons.data_button("Back", f"userset {user_id} back", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
 
         def_cookies = user_dict.get("USE_DEFAULT_COOKIE", False)
         cookie_mode = "Owner's Cookie" if def_cookies else "User's Cookie"
@@ -531,7 +532,7 @@ async def get_user_settings(from_user, stype="main"):
             thumb_layout = "None"
 
         buttons.data_button("Back", f"userset {user_id} back", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(2)
 
         text = f"""⌬ <b>Leech Settings :</b>
@@ -563,7 +564,7 @@ async def get_user_settings(from_user, stype="main"):
         buttons.data_button("DevUploads Tools", f"userset {user_id} devuploads")
         buttons.data_button("VikingFile Tools", f"userset {user_id} vikingfile")
         buttons.data_button("Back", f"userset {user_id} back", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         destinations = [s.capitalize() for s in uphoster_service.split(",")]
@@ -575,7 +576,7 @@ async def get_user_settings(from_user, stype="main"):
     elif stype == "pixeldrain":
         buttons.data_button("PixelDrain Key", f"userset {user_id} menu PIXELDRAIN_KEY")
         buttons.data_button("Back", f"userset {user_id} back uphoster", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         if user_dict.get("PIXELDRAIN_KEY", False):
@@ -598,7 +599,7 @@ async def get_user_settings(from_user, stype="main"):
             "BuzzHeavier Folder ID", f"userset {user_id} menu BUZZHEAVIER_FOLDER_ID"
         )
         buttons.data_button("Back", f"userset {user_id} back uphoster", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         if user_dict.get("BUZZHEAVIER_TOKEN", False):
@@ -623,7 +624,7 @@ async def get_user_settings(from_user, stype="main"):
         buttons.data_button("DevUploads API Key", f"userset {user_id} menu DEVUPLOADS_KEY")
         buttons.data_button("DevUploads Folder ID", f"userset {user_id} menu DEVUPLOADS_FOLDER")
         buttons.data_button("Back", f"userset {user_id} back uphoster", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         dukey = user_dict.get("DEVUPLOADS_KEY") or Config.DEVUPLOADS_KEY or "None"
@@ -638,7 +639,7 @@ async def get_user_settings(from_user, stype="main"):
         buttons.data_button("VikingFile Hash", f"userset {user_id} menu VIKINGFILE_HASH")
         buttons.data_button("VikingFile Folder", f"userset {user_id} menu VIKINGFILE_FOLDER")
         buttons.data_button("Back", f"userset {user_id} back uphoster", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         vfkey = user_dict.get("VIKINGFILE_HASH") or Config.VIKINGFILE_HASH or "None"
@@ -655,7 +656,7 @@ async def get_user_settings(from_user, stype="main"):
             "Gofile Folder ID", f"userset {user_id} menu GOFILE_FOLDER_ID"
         )
         buttons.data_button("Back", f"userset {user_id} back uphoster", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         if user_dict.get("GOFILE_TOKEN", False):
@@ -686,7 +687,7 @@ async def get_user_settings(from_user, stype="main"):
         buttons.data_button("Rclone Flags", f"userset {user_id} menu RCLONE_FLAGS")
 
         buttons.data_button("Back", f"userset {user_id} back mirror", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
 
         rccmsg = "Exists" if await aiopath.exists(rclone_conf) else "Not Exists"
         if user_dict.get("RCLONE_PATH", False):
@@ -732,7 +733,7 @@ async def get_user_settings(from_user, stype="main"):
             )
             sd_msg = "Disabled"
         buttons.data_button("Back", f"userset {user_id} back mirror", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
 
         tokenmsg = "Exists" if await aiopath.exists(token_pickle) else "Not Exists"
         if user_dict.get("GDRIVE_ID", False):
@@ -782,7 +783,7 @@ async def get_user_settings(from_user, stype="main"):
 
         buttons.data_button("YT Up Tools", f"userset {user_id} yttools")
         buttons.data_button("Back", f"userset {user_id} back", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         text = f"""⌬ <b>Mirror Settings :</b>
@@ -858,7 +859,7 @@ async def get_user_settings(from_user, stype="main"):
             display_subtitle_meta = f"<code>{display_subtitle_meta}</code>"
 
         buttons.data_button("Back", f"userset {user_id} back", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(2)
 
         text = f"""⌬ <b>FF Settings :</b>
@@ -916,7 +917,7 @@ async def get_user_settings(from_user, stype="main"):
         )
 
         buttons.data_button("Back", f"userset {user_id} back", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(1)
 
         text = f"""⌬ <b>Advanced Settings :</b>
@@ -965,7 +966,7 @@ async def get_user_settings(from_user, stype="main"):
         )
 
         buttons.data_button("Back", f"userset {user_id} back mirror", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         btns = buttons.build_menu(2)
 
         text = f"""⌬ <b>YouTube Tools Settings:</b>
@@ -1205,7 +1206,7 @@ async def get_menu(option, message, user_id):
     else:
         back_to = "back"
     buttons.data_button("Back", f"userset {user_id} {back_to}", "footer")
-    buttons.data_button("Close", f"userset {user_id} close", "footer")
+    buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
     val = user_dict.get(option)
     if option in file_dict and await aiopath.exists(file_dict[option]):
         val = "<b>Exists</b>"
@@ -1370,7 +1371,7 @@ async def edit_user_settings(client, query):
             )
 
         buttons.data_button("Back", f"userset {user_id} back uphoster", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
 
         text = f"""⌬ <b>Select Uphoster Destinations :</b>"""
         await edit_message(message, text, buttons.build_menu(1))
@@ -1394,7 +1395,7 @@ async def edit_user_settings(client, query):
         text = user_settings_text[data[3]][2]
         buttons.data_button("Stop", f"userset {user_id} menu {data[3]} stop")
         buttons.data_button("Back", f"userset {user_id} menu {data[3]}", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         prompt_title = data[3].replace("_", " ").title()
         new_message_text = f"⌬ <b>Set {prompt_title}</b>\n\n{text}"
         await edit_message(message, new_message_text, buttons.build_menu(1))
@@ -1422,7 +1423,7 @@ async def edit_user_settings(client, query):
             func = remove_one
         buttons.data_button("Stop", f"userset {user_id} menu {data[3]} stop")
         buttons.data_button("Back", f"userset {user_id} menu {data[3]}", "footer")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         await edit_message(
             message, message.text.html + "\n\n" + text, buttons.build_menu(1)
         )
@@ -1463,7 +1464,7 @@ async def edit_user_settings(client, query):
         buttons = ButtonMaker()
         buttons.data_button("Yes", f"userset {user_id} do_reset_all yes")
         buttons.data_button("No", f"userset {user_id} do_reset_all no")
-        buttons.data_button("Close", f"userset {user_id} close", "footer")
+        buttons.data_button("Close", f"userset {user_id} close", "footer", style=ButtonStyle.DANGER)
         text = "<i>Are you sure you want to reset all your user settings?</i>"
         await edit_message(query.message, text, buttons.build_menu(2))
     elif data[2] == "do_reset_all":


### PR DESCRIPTION
## Summary by Sourcery

Standardize inline button styling across the bot by introducing support for button styles and applying a danger style to all Close actions.

Enhancements:
- Extend the button builder to support styled URL and data buttons with sensible default styles.
- Apply a consistent danger (red) style to Close buttons across user settings, bot settings, RSS, plugins, help, cancel-task, IMDb, logging, and stats interfaces for clearer destructive-action affordance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional config to enable colored inline buttons for richer, more consistent UI.

* **Style**
  * Standardized inline button visuals: danger for Close/Cancel, success for confirm/done, primary for links/views/headers.
  * Button creation now supports explicit style selection so menus across settings, search, media, listings, logs, and task flows appear more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->