### PR TITLE
feat: NZB ID shorthand and API key hiding

### DIFF
--- a/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
@@ -11,24 +11,6 @@ from ...ext_utils.status_utils import (
 )
 
 
-def _display_name(raw_name):
-    if not raw_name:
-        return raw_name
-    if "getnzb/api/" in raw_name:
-        try:
-            return f"NZB ID: {raw_name.split('getnzb/api/')[1].split('?')[0]}"
-        except Exception:
-            return raw_name
-    if "/getnzb/" in raw_name and "apikey=" in raw_name:
-        try:
-            parts = raw_name.split("/getnzb/")[1]
-            nzb_id = parts.split("?")[0].split("/")[0]
-            return f"NZB ID: {nzb_id}"
-        except Exception:
-            return raw_name
-    return raw_name
-
-
 async def get_download(nzo_id, old_info=None):
     if old_info is None:
         old_info = defaultdict(lambda: "")

--- a/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
@@ -11,15 +11,44 @@ from ...ext_utils.status_utils import (
 )
 
 
+def _display_name(raw_name):
+    if not raw_name:
+        return raw_name
+    if "getnzb/api/" in raw_name:
+        try:
+            return f"NZB ID: {raw_name.split('getnzb/api/')[1].split('?')[0]}"
+        except Exception:
+            return raw_name
+    if "/getnzb/" in raw_name and "apikey=" in raw_name:
+        try:
+            parts = raw_name.split("/getnzb/")[1]
+            nzb_id = parts.split("?")[0].split("/")[0]
+            return f"NZB ID: {nzb_id}"
+        except Exception:
+            return raw_name
+    return raw_name
+
+
 async def get_download(nzo_id, old_info=None):
     if old_info is None:
-        old_info = {}
+        old_info = defaultdict(lambda: "")
     try:
         queue = await sabnzbd_client.get_downloads(nzo_ids=nzo_id)
         if res := queue["queue"]["slots"]:
             slot = res[0]
             if msg := slot["labels"]:
-                LOGGER.warning(" | ".join(msg))
+                filtered_msgs = []
+                for m in msg:
+                    if "apikey=" in m or "Trying to fetch NZB from" in m:
+                        if "getnzb/api/" in m:
+                            nzb_id = m.split("getnzb/api/")[1].split("?")[0]
+                            filtered_msgs.append(f"Fetching NZB ID: {nzb_id}")
+                        else:
+                            filtered_msgs.append("Fetching NZB...")
+                    else:
+                        filtered_msgs.append(m)
+                if filtered_msgs:
+                    LOGGER.warning(" | ".join(filtered_msgs))
             return slot
         else:
             history = await sabnzbd_client.get_history(nzo_ids=nzo_id)
@@ -63,8 +92,12 @@ class SabnzbdStatus:
         self.queued = queued
         self.listener = listener
         self._gid = gid
-        self._info = {}
+        self._info = defaultdict(lambda: "")
         self.engine = EngineStatus().STATUS_SABNZBD
+        if hasattr(listener, "nzb_id") and listener.nzb_id:
+            self._display_name = f"NZB ID: {listener.nzb_id}"
+        else:
+            self._display_name = None
 
     async def update(self):
         self._info = await get_download(self._gid, self._info)
@@ -92,7 +125,15 @@ class SabnzbdStatus:
         return f"{get_readable_file_size(self.speed_raw())}/s"
 
     def name(self):
-        return self._info.get("filename", "")
+        filename = self._info.get("filename", "")
+        if self._display_name and (not filename or "Trying to fetch" in filename):
+            return self._display_name
+        if filename and "apikey=" in filename:
+            if "getnzb/api/" in filename:
+                nzb_id = filename.split("getnzb/api/")[1].split("?")[0]
+                return f"NZB ID: {nzb_id}"
+            return "Fetching NZB..."
+        return filename or self._display_name or "Fetching NZB..."
 
     def size(self):
         return self._info.get("size", 0)

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -458,10 +458,11 @@ async def nzb_mirror(client, message):
     nzb_id = None
     if len(text_parts) > 1 and not text_parts[1].startswith(("http", "ftp", "/")):
         potential_id = text_parts[1]
-        if potential_id.replace("-", "").replace("_", "").isalnum():
+        if not potential_id.startswith("-") and potential_id.replace("-", "").replace("_", "").isalnum():
             nzb_id = potential_id
             nzb_url = f"{Config.HYDRA_IP}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
-            message.text = f"/nzbmirror {nzb_url} -e"
+            extra = " ".join(text_parts[2:])
+            message.text = f"/nzbmirror {nzb_url} -e {extra}".strip()
     else:
         if "-e" not in message.text:
             message.text += " -e"
@@ -493,10 +494,11 @@ async def nzb_leech(client, message):
     nzb_id = None
     if len(text_parts) > 1 and not text_parts[1].startswith(("http", "ftp", "/")):
         potential_id = text_parts[1]
-        if potential_id.replace("-", "").replace("_", "").isalnum():
+        if not potential_id.startswith("-") and potential_id.replace("-", "").replace("_", "").isalnum():
             nzb_id = potential_id
             nzb_url = f"{Config.HYDRA_IP}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
-            message.text = f"/nzbleech {nzb_url} -e"
+            extra = " ".join(text_parts[2:])
+            message.text = f"/nzbleech {nzb_url} -e {extra}".strip()
     else:
         if "-e" not in message.text:
             message.text += " -e"

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -454,7 +454,21 @@ async def jd_mirror(client, message):
 
 
 async def nzb_mirror(client, message):
-    bot_loop.create_task(Mirror(client, message, is_nzb=True).new_event())
+    text_parts = message.text.split()
+    nzb_id = None
+    if len(text_parts) > 1 and not text_parts[1].startswith(("http", "ftp", "/")):
+        potential_id = text_parts[1]
+        if potential_id.replace("-", "").replace("_", "").isalnum():
+            nzb_id = potential_id
+            nzb_url = f"{Config.HYDRA_IP}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
+            message.text = f"/nzbmirror {nzb_url} -e"
+    else:
+        if "-e" not in message.text:
+            message.text += " -e"
+    mirror_task = Mirror(client, message, is_nzb=True)
+    if nzb_id:
+        mirror_task.nzb_id = nzb_id
+    bot_loop.create_task(mirror_task.new_event())
 
 
 async def leech(client, message):
@@ -475,9 +489,21 @@ async def jd_leech(client, message):
 
 
 async def nzb_leech(client, message):
-    bot_loop.create_task(
-        Mirror(client, message, is_leech=True, is_nzb=True).new_event()
-    )
+    text_parts = message.text.split()
+    nzb_id = None
+    if len(text_parts) > 1 and not text_parts[1].startswith(("http", "ftp", "/")):
+        potential_id = text_parts[1]
+        if potential_id.replace("-", "").replace("_", "").isalnum():
+            nzb_id = potential_id
+            nzb_url = f"{Config.HYDRA_IP}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
+            message.text = f"/nzbleech {nzb_url} -e"
+    else:
+        if "-e" not in message.text:
+            message.text += " -e"
+    mirror_task = Mirror(client, message, is_leech=True, is_nzb=True)
+    if nzb_id:
+        mirror_task.nzb_id = nzb_id
+    bot_loop.create_task(mirror_task.new_event())
 
 
 async def uphoster(client, message):

--- a/bot/modules/nzb_search.py
+++ b/bot/modules/nzb_search.py
@@ -108,10 +108,19 @@ async def create_telegraph_page(query, items):
         )
         size = get_readable_file_size(size_bytes)
 
+        nzb_id = "Unknown"
+        if "getnzb/api/" in download_url:
+            try:
+                nzb_id = download_url.split("getnzb/api/")[1].split("?")[0]
+            except Exception:
+                pass
+
         content += (
             f"{idx}. {title}<br>"
-            f"<b><a href='{download_url}'>Download URL</a> | <a href='http://t.me/share/url?url={download_url}'>Share Download URL</a></b><br>"
+            f"<b>NZB ID:</b> <code>{nzb_id}</code><br>"
             f"<b>Size:</b> {size}<br>"
+            f"<b>Mirror:</b> <code>/nm {nzb_id}</code><br>"
+            f"<b>Leech:</b> <code>/nl {nzb_id}</code><br>"
             f"━━━━━━━━━━━━━━━━━━━━━━<br><br>"
         )
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for using NZB IDs directly while hiding sensitive API keys from logs and user-facing messages.

New Features:
- Allow NZB mirror and leech commands to accept a shorthand NZB ID instead of a full URL.
- Display NZB IDs and corresponding mirror/leech command snippets in NZB search results.

Enhancements:
- Mask or replace NZB URLs containing API keys in filenames and log messages with NZB ID–based placeholders or generic status text.
- Preserve and reuse NZB IDs in SABnzbd status displays to provide cleaner, more consistent task names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mirror and leech commands accept raw NZB identifiers (auto-converted to fetchable form)
  * Search results include NZB IDs and quick /nm and /nl command shortcuts

* **Improvements**
  * Status display better identifies NZBs and shows friendly names when available
  * NZB-related logging simplified to surface relevant fetch messages only
<!-- end of auto-generated comment: release notes by coderabbit.ai -->