### PR TITLE
fix: HYDRA_IP double-slash and negative NZB ID rejection

### DIFF
--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -458,9 +458,10 @@ async def nzb_mirror(client, message):
     nzb_id = None
     if len(text_parts) > 1 and not text_parts[1].startswith(("http", "ftp", "/")):
         potential_id = text_parts[1]
-        if not potential_id.startswith("-") and potential_id.replace("-", "").replace("_", "").isalnum():
+        clean = potential_id.lstrip("-").replace("_", "")
+        if clean.isalnum() and not (potential_id.startswith("-") and clean.isalpha()):
             nzb_id = potential_id
-            nzb_url = f"{Config.HYDRA_IP}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
+            nzb_url = f"{Config.HYDRA_IP.rstrip('/')}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
             extra = " ".join(text_parts[2:])
             message.text = f"/nzbmirror {nzb_url} -e {extra}".strip()
     else:
@@ -494,9 +495,10 @@ async def nzb_leech(client, message):
     nzb_id = None
     if len(text_parts) > 1 and not text_parts[1].startswith(("http", "ftp", "/")):
         potential_id = text_parts[1]
-        if not potential_id.startswith("-") and potential_id.replace("-", "").replace("_", "").isalnum():
+        clean = potential_id.lstrip("-").replace("_", "")
+        if clean.isalnum() and not (potential_id.startswith("-") and clean.isalpha()):
             nzb_id = potential_id
-            nzb_url = f"{Config.HYDRA_IP}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
+            nzb_url = f"{Config.HYDRA_IP.rstrip('/')}/getnzb/api/{nzb_id}?apikey={Config.HYDRA_API_KEY}"
             extra = " ".join(text_parts[2:])
             message.text = f"/nzbleech {nzb_url} -e {extra}".strip()
     else:

--- a/bot/modules/nzb_search.py
+++ b/bot/modules/nzb_search.py
@@ -44,7 +44,7 @@ async def hydra_search(_, message):
 
 
 async def search_nzbhydra(query, limit=50):
-    search_url = f"{Config.HYDRA_IP}/api"
+    search_url = f"{Config.HYDRA_IP.rstrip('/')}/api"
     params = {
         "apikey": Config.HYDRA_API_KEY,
         "t": "search",


### PR DESCRIPTION
## Summary by Sourcery

Adjust NZB handling and Hydra URL construction to avoid malformed requests and unintended ID rejections.

Bug Fixes:
- Prevent HYDRA_IP configuration values with trailing slashes from producing double slashes in NZBHydra API URLs.
- Refine NZB ID validation in mirror and leech commands to avoid incorrectly rejecting valid IDs that contain leading dashes or underscores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed malformed URLs in Hydra API calls that could occur with certain configuration formats.
* Improved NZB ID validation to ensure proper handling of special characters in identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->