### PR TITLE
shorten cancel GID

### DIFF
--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -84,7 +84,7 @@ async def get_task_by_gid(gid: str):
         for tk in task_dict.values():
             if hasattr(tk, "seeding"):
                 await tk.update()
-            if tk.gid() == gid:
+            if tk.gid().startswith(gid):
                 return tk
         return None
 
@@ -279,7 +279,7 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
         # TODO: Add Bt Sel
         from ..telegram_helper.bot_commands import BotCommands
 
-        msg += f"\n<b>┖ Stop</b> → <i>/{BotCommands.CancelTaskCommand[1]}_{task.gid()}</i>\n\n"
+        msg += f"\n<b>┖ Stop</b> → <i>/{BotCommands.CancelTaskCommand[1]}_{task.gid()[:8]}</i>\n\n"
 
     if len(msg) == 0:
         if status == "All":


### PR DESCRIPTION
## Summary by Sourcery

Allow tasks to be cancelled using a shortened GID prefix and update the stop command message to display only the first eight characters of the task GID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task lookup now works with partial task IDs (first 8 characters) instead of requiring full identifiers
  * UI display now consistently shows shortened task IDs (8 characters), improving alignment with the new lookup behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->