### PR TITLE
shorten cancel GID

### DIFF
--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -84,7 +84,7 @@ async def get_task_by_gid(gid: str):
         for tk in task_dict.values():
             if hasattr(tk, "seeding"):
                 await tk.update()
-            if tk.gid() == gid:
+            if tk.gid() == gid or tk.gid().startswith(gid):
                 return tk
         return None
 
@@ -279,7 +279,7 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
         # TODO: Add Bt Sel
         from ..telegram_helper.bot_commands import BotCommands
 
-        msg += f"\n<b>┖ Stop</b> → <i>/{BotCommands.CancelTaskCommand[1]}_{task.gid()}</i>\n\n"
+        msg += f"\n<b>┖ Stop</b> → <i>/{BotCommands.CancelTaskCommand[1]}_{task.gid()[:8]}</i>\n\n"
 
     if len(msg) == 0:
         if status == "All":


### PR DESCRIPTION
## Summary by Sourcery

Support abbreviated task GIDs when cancelling tasks via bot commands.

New Features:
- Allow cancelling tasks by specifying a GID prefix instead of the full GID in bot commands.

Enhancements:
- Display only the shortened (first 8 characters) task GID in the generated cancel command to simplify user interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task lookup now supports partial identifier matching using shorter prefixes.
  * Stop button commands now display abbreviated task identifiers for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->