### PR TITLE
buzzheavier update

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs, urlparse
 from urllib3.util.retry import Retry
 from uuid import uuid4
 from base64 import b64decode, b64encode
+from curl_cffi import Session as CurlSession
 
 from ....core.config_manager import Config
 from ...ext_utils.exceptions import DirectDownloadLinkException
@@ -380,36 +381,25 @@ def buzzheavier(url):
     if not match(pattern, url):
         return url
 
-    def _bhscraper(url, folder=False):
-        session = Session()
+    def _bhscraper(session , url):
         if "/download" not in url:
             url += "/download"
         url = url.strip()
-        session.headers.update(
-            {
-                "referer": url.split("/download")[0],
-                "hx-current-url": url.split("/download")[0],
-                "hx-request": "true",
-                "priority": "u=1, i",
-            }
-        )
         try:
-            response = session.get(url)
-            d_url = response.headers.get("Hx-Redirect")
+            response = session.get(url , allow_redirects=False)
+            d_url = response.headers.get("location","").strip()
             if not d_url:
-                if not folder:
-                    raise DirectDownloadLinkException("ERROR: Gagal mendapatkan data")
                 return
             return d_url
         except Exception as e:
             raise DirectDownloadLinkException(f"ERROR: {str(e)}") from e
 
-    with Session() as session:
-        tree = HTML(session.get(url).text)
-        if link := tree.xpath(
-            "//a[contains(@class, 'link-button') and contains(@class, 'gay-button')]/@hx-get"
-        ):
-            return _bhscraper(f"https://buzzheavier.com{link[0]}")
+    with CurlSession(impersonate = "chrome") as session:
+        response = session.get(url)
+        tree = HTML(response.text)
+        if link := tree.xpath("//a[contains(@hx-get, 'download')]"):
+            hx_get = link[0].attrib.get("hx-get", "").strip()
+            return _bhscraper(session , f"https://buzzheavier.com{hx_get}")
         elif folders := tree.xpath("//tbody[@id='tbody']/tr"):
             details = {"contents": [], "title": "", "total_size": 0}
             for data in folders:
@@ -417,7 +407,9 @@ def buzzheavier(url):
                     filename = data.xpath(".//a")[0].text.strip()
                     _id = data.xpath(".//a")[0].attrib.get("href", "").strip()
                     size = data.xpath(".//td[@class='text-center']/text()")[0].strip()
-                    url = _bhscraper(f"https://buzzheavier.com{_id}", True)
+                    url = buzzheavier(f"https://buzzheavier.com{_id}")
+                    if not url:
+                        raise DirectDownloadLinkException("ERROR: No download link found")
                     item = {
                         "path": "",
                         "filename": filename,
@@ -432,7 +424,6 @@ def buzzheavier(url):
             return details
         else:
             raise DirectDownloadLinkException("ERROR: No download link found")
-
 
 def fuckingfast_dl(url):
     """


### PR DESCRIPTION
This works only when Cloudflare is not blocking the hosted IP address.

## Summary by Sourcery

Update buzzheavier direct-link generation to use a CurlSession with browser impersonation and adjust scraping of download links for improved compatibility.

Bug Fixes:
- Fix buzzheavier download resolution by reading redirect URLs from Location headers instead of Hx-Redirect response headers and handling folder entries via recursive buzzheavier calls.

Enhancements:
- Simplify buzzheavier scraping logic and add stricter error handling when no download link is found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct-link extraction mechanism for enhanced reliability and compatibility.

* **Refactor**
  * Optimized link parsing logic for better performance.
  * Simplified internal helper function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->