### PR TITLE
Fallback to title tag for language code detection

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -161,10 +161,11 @@ async def get_media_info(path, extra_info=False):
                 qual = int(streams[0].get("height"))
                 qual = f"{480 if qual <= 480 else 540 if qual <= 540 else 720 if qual <= 720 else 1080 if qual <= 1080 else 2160 if qual <= 2160 else 4320 if qual <= 4320 else 8640}p"
                 for stream in streams:
+                    tags = stream.get("tags", {})
                     if stream.get("codec_type") == "audio" and (
-                        lc := stream.get("tags", {}).get("language")
+                        lc := tags.get("language") or tags.get("title")
                     ):
-                        with suppress(Exception):
+                         with suppress(Exception):
                             lc = Language.get(lc).display_name()
                         if lc not in lang:
                             lang += f"{lc}, "


### PR DESCRIPTION
For some files where the language tag is not set properly, the title tag may still contain a valid language code.

## Summary by Sourcery

Bug Fixes:
- Handle cases where the audio stream language tag is unset by using the title tag as a fallback for language code detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio track language information display by implementing a fallback mechanism. Audio language metadata will now be more complete when certain fields are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->