### PR TITLE
fix: allow credentials in upstream URL regex for private repo support

### DIFF
--- a/update.py
+++ b/update.py
@@ -21,7 +21,7 @@ getLogger("pymongo").setLevel(ERROR)
 
 _DB_PARTITION_SALT = b"wzmlx_v3_db_partition_salt"
 _ALLOWED_UPSTREAM = re_compile(
-    r"^https://(github\.com/[\w.-]+/[\w.-]+/?|raw\.githubusercontent\.com/[\w.-]+/[\w.-]+/?)$"
+    r"^https://(?:[\w.-]+:[\w.-]+@)?(github\.com/[\w.-]+/[\w.-]+/?|raw\.githubusercontent\.com/[\w.-]+/[\w.-]+/?)$"
 )
 _BRANCH_RE = re_compile(r"^[\w./-]+$")
 


### PR DESCRIPTION
## Problem
Private GitHub repos require token-based auth in the URL format:
`https://user:token@github.com/...`

The existing regex rejected these URLs, breaking private repo support.

## Fix
Added optional `(?:[\w.-]+:[\w.-]+@)?` group to allow credentials in upstream URLs.

## Summary by Sourcery

Bug Fixes:
- Fix upstream URL regex to permit HTTPS GitHub and raw.githubusercontent.com URLs containing optional user:token credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upstream repository URL validation to accept GitHub URLs with embedded authentication credentials (e.g., username:token@).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->