### PR TITLE
fix: audio quality button text, typo, and broken cancel handler

### DIFF
--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -228,11 +228,11 @@ class YtSelection:
         buttons = ButtonMaker()
         for qual in range(11):
             audio_format = f"{format}{qual}"
-            buttons.data_button(qual, f"ytq {audio_format}")
+            buttons.data_button(str(qual), f"ytq {audio_format}")
         buttons.data_button("Back", "ytq aq back")
-        buttons.data_button("Cancel", "ytq aq cancel")
+        buttons.data_button("Cancel", "ytq cancel")
         subbuttons = buttons.build_menu(5)
-        msg = f"Choose Audio{i} Qaulity:\n0 is best and 10 is worst\nTimeout: {get_readable_time(self._timeout - (time() - self._time))}"
+        msg = f"Choose Audio{i} Quality:\n0 is best and 10 is worst\nTimeout: {get_readable_time(self._timeout - (time() - self._time))}"
         await edit_message(self._reply_to, msg, subbuttons)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Fix audio quality selection UI labels and cancel handler wiring.

Bug Fixes:
- Ensure audio quality buttons send string labels instead of integers to avoid callback issues.
- Wire the audio quality cancel button to the correct callback action.

Enhancements:
- Correct the typo in the audio quality prompt text shown to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling error in audio quality selection prompt
  * Improved formatting consistency for quality option buttons
  * Standardized cancel button behavior in quality selection interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->