### PR TITLE
fix: guard reply_to.text None check

### DIFF
--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -449,7 +449,8 @@ class YtDlp(TaskListener):
         opt = opt or self.user_dict.get("YT_DLP_OPTIONS") or Config.YT_DLP_OPTIONS
 
         if not self.link and (reply_to := self.message.reply_to_message):
-            self.link = reply_to.text.split("\n", 1)[0].strip()
+            if reply_to.text:
+                self.link = reply_to.text.split("\n", 1)[0].strip()
 
         if not is_url(self.link):
             await send_message(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Avoid attribute access on None by checking that reply_to.text is present before parsing the link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when processing replies without text content, improving application stability and reliability when handling various message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->