### PR TITLE
mount host time zone to container for finding logs crash time etc easily

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
 
   app:
     build: .
+    environment:
+      - TZ=${TZ:-UTC}
     command: bash start.sh
     restart: unless-stopped
     volumes:
@@ -32,8 +34,6 @@ services:
       - ./accounts:/usr/src/app/accounts
       - ./downloads:/usr/src/app/downloads
       - ./sabnzbd:/usr/src/app/sabnzbd
-      - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
     expose:
       - "8080"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - ./accounts:/usr/src/app/accounts
       - ./downloads:/usr/src/app/downloads
       - ./sabnzbd:/usr/src/app/sabnzbd
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     expose:
       - "8080"
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Mount host /etc/localtime and /etc/timezone into the app container to ensure container time matches the host system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container runtime now uses the host timezone when provided, and falls back to UTC if no timezone is specified. This ensures consistent display and processing of time-related information across environments and avoids unexpected timezone differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->