### PR TITLE
fix: correct 7z zip cmd index when removing empty -p password flag

### DIFF
--- a/bot/helper/ext_utils/files_utils.py
+++ b/bot/helper/ext_utils/files_utils.py
@@ -420,12 +420,12 @@ class SevenZ:
         ]
         if self._listener.is_leech and int(size) > self._listener.split_size:
             if not pswd:
-                del cmd[4]
+                del cmd[5]
             LOGGER.info(f"Zip: orig_path: {dl_path}, zip_path: {up_path}.0*")
         else:
             del cmd[1]
             if not pswd:
-                del cmd[3]
+                del cmd[4]
             LOGGER.info(f"Zip: orig_path: {dl_path}, zip_path: {up_path}")
         if self._listener.is_cancelled:
             return False


### PR DESCRIPTION
The del cmd indices for removing the empty password flag (-p) were wrong. In the non-leech branch, del cmd[3] removed -mmt=on instead of -p. In the leech branch, del cmd[4] removed -mmt=on instead of -p. This left the -p flag which makes 7z prompt for a password interactively, causing zip to fail silently for -z without a password.

## Summary by Sourcery

Bug Fixes:
- Ensure the -p password flag is correctly removed instead of -mmt=on when no password is provided in both leech and non-leech branches of the zip flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 7z archive extraction when no password is provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->