### PR TITLE
chore: Reply for exps

### DIFF
--- a/bot/core/handlers.py
+++ b/bot/core/handlers.py
@@ -413,8 +413,7 @@ def add_handlers():
     TgClient.bot.add_handler(
         MessageHandler(
             gen_pyro_string,
-            filters=command(BotCommands.GenPyroSessCommand, case_sensitive=True)
-            & CustomFilters.sudo,
+            filters=command(BotCommands.GenPyroSessCommand, case_sensitive=True),
         )
     )
     TgClient.bot.add_handler(

--- a/bot/modules/gen_pyro_sess.py
+++ b/bot/modules/gen_pyro_sess.py
@@ -126,21 +126,18 @@ async def _stop_or_timeout(value, msg, h, c, pyro_client=None):
 
 @new_task
 async def gen_pyro_string(_, message):
-    if message.chat.type != ChatType.PRIVATE:
-        return await send_message(
-            message,
-            "<i>This command can only be used in <b>Private Chat</b>.</i>",
-        )
-
     user_id = message.from_user.id
     if (
-        user_id != Config.OWNER_ID
-        and user_id not in sudo_users
-        and not user_data.get(user_id, {}).get("SUDO")
+        message.chat.type != ChatType.PRIVATE
+        or (
+            user_id != Config.OWNER_ID
+            and user_id not in sudo_users
+            and not user_data.get(user_id, {}).get("SUDO")
+        )
     ):
         return await send_message(
             message,
-            "<i>This command is only for <b>Owner</b> &amp; <b>Sudo</b> users.</i>",
+            "<i>This command is only for <b>Owner</b> &amp; <b>Sudo</b> users in <b>Private Chat</b>.</i>",
         )
 
     user_name = message.from_user.first_name or "User"

--- a/bot/modules/gen_pyro_sess.py
+++ b/bot/modules/gen_pyro_sess.py
@@ -126,10 +126,13 @@ async def _stop_or_timeout(value, msg, h, c, pyro_client=None):
 @new_task
 async def gen_pyro_string(_, message):
     if message.chat.type != ChatType.PRIVATE:
-        return
+        return await send_message(
+            message,
+            "<i>This command can only be used in <b>Private Chat</b>.</i>",
+        )
 
-    user_id = message.from_user.id
     user_name = message.from_user.first_name or "User"
+    user_id = message.from_user.id
     btns = _stop_btns()
     h = _header(user_name)
 

--- a/bot/modules/gen_pyro_sess.py
+++ b/bot/modules/gen_pyro_sess.py
@@ -17,6 +17,7 @@ from pyrogram.errors import (
 
 from ..core.tg_client import TgClient
 from ..core.config_manager import Config
+from .. import sudo_users, user_data
 from ..helper.ext_utils.bot_utils import new_task
 from ..helper.ext_utils.status_utils import get_readable_time
 from ..helper.telegram_helper.button_build import ButtonMaker
@@ -131,8 +132,18 @@ async def gen_pyro_string(_, message):
             "<i>This command can only be used in <b>Private Chat</b>.</i>",
         )
 
-    user_name = message.from_user.first_name or "User"
     user_id = message.from_user.id
+    if (
+        user_id != Config.OWNER_ID
+        and user_id not in sudo_users
+        and not user_data.get(user_id, {}).get("SUDO")
+    ):
+        return await send_message(
+            message,
+            "<i>This command is only for <b>Owner</b> &amp; <b>Sudo</b> users.</i>",
+        )
+
+    user_name = message.from_user.first_name or "User"
     btns = _stop_btns()
     h = _header(user_name)
 


### PR DESCRIPTION
## Summary by Sourcery

Restrict the gen_pyro_string command to owner and sudo users in private chats and update the handler to rely on the new in-command permission and chat checks.

Enhancements:
- Add in-command validation to limit gen_pyro_string usage to the owner and sudo users in private chats, returning a user-facing message when access is denied.
- Simplify the command handler configuration by removing the external sudo filter and delegating access control to the command implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Pyrogram String Session Generator command to display an access denied message when users lack required permissions, instead of silently failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->