### PR TITLE
fix: Restrict gen_pyro_string to private chats and use CustomFilters.sudo for auth

### DIFF
--- a/bot/core/handlers.py
+++ b/bot/core/handlers.py
@@ -1,6 +1,6 @@
 # ruff: noqa: F403, F405
 
-from pyrogram.filters import command, regex
+from pyrogram.filters import command, private, regex
 from pyrogram.handlers import CallbackQueryHandler, EditedMessageHandler, MessageHandler
 from pyrogram.types import BotCommand
 
@@ -58,9 +58,7 @@ def add_handlers():
     TgClient.bot.add_handler(
         MessageHandler(
             black_listed,
-            filters=regex(r"^/")
-            & CustomFilters.authorized
-            & CustomFilters.blacklisted,
+            filters=regex(r"^/") & CustomFilters.authorized & CustomFilters.blacklisted,
         )
     )
     TgClient.bot.add_handler(
@@ -413,13 +411,15 @@ def add_handlers():
     TgClient.bot.add_handler(
         MessageHandler(
             gen_pyro_string,
-            filters=command(BotCommands.GenPyroSessCommand, case_sensitive=True),
+            filters=command(BotCommands.GenPyroSessCommand, case_sensitive=True)
+            & private,
         )
     )
     TgClient.bot.add_handler(
         MessageHandler(
             change_category,
-            filters=command(BotCommands.CategorySelectCommand) & CustomFilters.authorized,
+            filters=command(BotCommands.CategorySelectCommand)
+            & CustomFilters.authorized,
         )
     )
     TgClient.bot.add_handler(

--- a/bot/core/handlers.py
+++ b/bot/core/handlers.py
@@ -413,8 +413,7 @@ def add_handlers():
     TgClient.bot.add_handler(
         MessageHandler(
             gen_pyro_string,
-            filters=command(BotCommands.GenPyroSessCommand, case_sensitive=True)
-            & CustomFilters.sudo,
+            filters=command(BotCommands.GenPyroSessCommand, case_sensitive=True),
         )
     )
     TgClient.bot.add_handler(

--- a/bot/modules/gen_pyro_sess.py
+++ b/bot/modules/gen_pyro_sess.py
@@ -17,6 +17,7 @@ from pyrogram.errors import (
 
 from ..core.tg_client import TgClient
 from ..core.config_manager import Config
+from .. import sudo_users, user_data
 from ..helper.ext_utils.bot_utils import new_task
 from ..helper.ext_utils.status_utils import get_readable_time
 from ..helper.telegram_helper.button_build import ButtonMaker
@@ -125,10 +126,20 @@ async def _stop_or_timeout(value, msg, h, c, pyro_client=None):
 
 @new_task
 async def gen_pyro_string(_, message):
-    if message.chat.type != ChatType.PRIVATE:
-        return
-
     user_id = message.from_user.id
+    if (
+        message.chat.type != ChatType.PRIVATE
+        or (
+            user_id != Config.OWNER_ID
+            and user_id not in sudo_users
+            and not user_data.get(user_id, {}).get("SUDO")
+        )
+    ):
+        return await send_message(
+            message,
+            "<i>This command is only for <b>Owner</b> &amp; <b>Sudo</b> users in <b>Private Chat</b>.</i>",
+        )
+
     user_name = message.from_user.first_name or "User"
     btns = _stop_btns()
     h = _header(user_name)

--- a/bot/modules/gen_pyro_sess.py
+++ b/bot/modules/gen_pyro_sess.py
@@ -3,7 +3,6 @@ from os.path import exists as path_exists
 
 from aiofiles.os import remove as aioremove
 from pyrogram import Client
-from pyrogram.enums import ChatType
 from pyrogram.filters import create, user, text, private
 from pyrogram.handlers import CallbackQueryHandler, MessageHandler
 from pyrogram.errors import (
@@ -17,11 +16,15 @@ from pyrogram.errors import (
 
 from ..core.tg_client import TgClient
 from ..core.config_manager import Config
-from .. import sudo_users, user_data
 from ..helper.ext_utils.bot_utils import new_task
 from ..helper.ext_utils.status_utils import get_readable_time
 from ..helper.telegram_helper.button_build import ButtonMaker
-from ..helper.telegram_helper.message_utils import send_message, edit_message, delete_message
+from ..helper.telegram_helper.filters import CustomFilters
+from ..helper.telegram_helper.message_utils import (
+    send_message,
+    edit_message,
+    delete_message,
+)
 
 _STOP = "gensess_stop"
 _TIMEOUT = 120
@@ -30,6 +33,7 @@ _TIMEOUT = 120
 def _stop_filter(uid):
     async def _check(_, __, update):
         return update.data == _STOP and update.from_user.id == uid
+
     return create(_check)
 
 
@@ -66,11 +70,17 @@ def _collected(api_id=None, api_hash=None, phone=None):
 
 
 def _stop_msg(h, c):
-    return f"{h}\n┃\n" + (f"{c}\n┃\n┖ <b>Process Stopped.</b>" if c else "┖ <b>Process Stopped.</b>")
+    return f"{h}\n┃\n" + (
+        f"{c}\n┃\n┖ <b>Process Stopped.</b>" if c else "┖ <b>Process Stopped.</b>"
+    )
 
 
 def _timeout_msg(h, c):
-    return f"{h}\n┃\n" + (f"{c}\n┃\n┃ <b>Timed Out!</b>\n┖ <i>Process Stopped.</i>" if c else "┃ <b>Timed Out!</b>\n┖ <i>Process Stopped.</i>")
+    return f"{h}\n┃\n" + (
+        f"{c}\n┃\n┃ <b>Timed Out!</b>\n┖ <i>Process Stopped.</i>"
+        if c
+        else "┃ <b>Timed Out!</b>\n┖ <i>Process Stopped.</i>"
+    )
 
 
 def _error_msg(h, c, err):
@@ -127,17 +137,10 @@ async def _stop_or_timeout(value, msg, h, c, pyro_client=None):
 @new_task
 async def gen_pyro_string(_, message):
     user_id = message.from_user.id
-    if (
-        message.chat.type != ChatType.PRIVATE
-        or (
-            user_id != Config.OWNER_ID
-            and user_id not in sudo_users
-            and not user_data.get(user_id, {}).get("SUDO")
-        )
-    ):
+    if not await CustomFilters.sudo("", message):
         return await send_message(
             message,
-            "<i>This command is only for <b>Owner</b> &amp; <b>Sudo</b> users in <b>Private Chat</b>.</i>",
+            "<i>This command is only for <b>Owner</b> &amp; <b>Sudo</b> users.</i>",
         )
 
     user_name = message.from_user.first_name or "User"
@@ -165,7 +168,9 @@ async def gen_pyro_string(_, message):
         try:
             api_id = int(api_id)
         except ValueError:
-            return await edit_message(sess_msg, _error_msg(h, "", "<i><code>APP_ID</code> is Invalid.</i>"))
+            return await edit_message(
+                sess_msg, _error_msg(h, "", "<i><code>APP_ID</code> is Invalid.</i>")
+            )
 
         c = _collected(api_id=api_id)
         await edit_message(
@@ -182,7 +187,9 @@ async def gen_pyro_string(_, message):
         if await _stop_or_timeout(api_hash, sess_msg, h, c):
             return
         if len(api_hash) <= 30:
-            return await edit_message(sess_msg, _error_msg(h, c, "<i><code>API_HASH</code> is Invalid.</i>"))
+            return await edit_message(
+                sess_msg, _error_msg(h, c, "<i><code>API_HASH</code> is Invalid.</i>")
+            )
 
         c = _collected(api_id=api_id, api_hash=api_hash)
     else:
@@ -233,7 +240,9 @@ async def gen_pyro_string(_, message):
             workdir="/usr/src/app",
         )
     except Exception as e:
-        return await edit_message(sess_msg, _error_msg(h, c, f"<b>Client Error:</b> <i>{e}</i>"))
+        return await edit_message(
+            sess_msg, _error_msg(h, c, f"<b>Client Error:</b> <i>{e}</i>")
+        )
 
     try:
         await pyro_client.connect()
@@ -245,13 +254,29 @@ async def gen_pyro_string(_, message):
         user_code = await pyro_client.send_code(phone_no)
     except FloodWait as e:
         await _safe_disconnect(pyro_client)
-        return await edit_message(sess_msg, _error_msg(h, c, f"<b>FloodWait:</b> <i>Retry after {get_readable_time(e.value)}.</i>"))
+        return await edit_message(
+            sess_msg,
+            _error_msg(
+                h,
+                c,
+                f"<b>FloodWait:</b> <i>Retry after {get_readable_time(e.value)}.</i>",
+            ),
+        )
     except ApiIdInvalid:
         await _safe_disconnect(pyro_client)
-        return await edit_message(sess_msg, _error_msg(h, c, "<i><code>API_ID</code> and <code>API_HASH</code> are Invalid.</i>"))
+        return await edit_message(
+            sess_msg,
+            _error_msg(
+                h,
+                c,
+                "<i><code>API_ID</code> and <code>API_HASH</code> are Invalid.</i>",
+            ),
+        )
     except PhoneNumberInvalid:
         await _safe_disconnect(pyro_client)
-        return await edit_message(sess_msg, _error_msg(h, c, "<i>Phone Number is Invalid.</i>"))
+        return await edit_message(
+            sess_msg, _error_msg(h, c, "<i>Phone Number is Invalid.</i>")
+        )
 
     await edit_message(
         sess_msg,
@@ -299,10 +324,14 @@ async def gen_pyro_string(_, message):
             await pyro_client.check_password(password.strip())
         except Exception as e:
             await _safe_disconnect(pyro_client)
-            return await edit_message(sess_msg, _error_msg(h, c, f"<b>Password Error:</b> <i>{e}</i>"))
+            return await edit_message(
+                sess_msg, _error_msg(h, c, f"<b>Password Error:</b> <i>{e}</i>")
+            )
     except Exception as e:
         await _safe_disconnect(pyro_client)
-        return await edit_message(sess_msg, _error_msg(h, c, f"<b>Sign In Error:</b> <i>{e}</i>"))
+        return await edit_message(
+            sess_msg, _error_msg(h, c, f"<b>Sign In Error:</b> <i>{e}</i>")
+        )
 
     try:
         session_string = await pyro_client.export_session_string()
@@ -323,7 +352,9 @@ async def gen_pyro_string(_, message):
         )
     except Exception as e:
         await _safe_disconnect(pyro_client)
-        return await edit_message(sess_msg, _error_msg(h, c, f"<b>Export Error:</b> <i>{e}</i>"))
+        return await edit_message(
+            sess_msg, _error_msg(h, c, f"<b>Export Error:</b> <i>{e}</i>")
+        )
 
     for ext in ("session", "session-journal"):
         path = f"WZML-X-{user_id}.{ext}"


### PR DESCRIPTION
…sudo for auth

## Summary by Sourcery

Restrict the Pyrogram session generation command to private chats and centralize its sudo authorization via CustomFilters, while performing minor formatting cleanups.

Bug Fixes:
- Ensure the Pyrogram session generation command is only accessible to owner/sudo users using the shared CustomFilters.sudo auth logic.
- Limit the Pyrogram session generation command to private chats via the message handler filters.

Enhancements:
- Reformat helper message construction and error handling calls for improved readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling with clearer, more informative error messages for authentication failures, invalid credentials, connection issues, and rate limiting, including retry guidance.
  * Strengthened access control validation for sensitive administrative commands.

* **Refactor**
  * Optimized internal handler filter logic and consolidated access control checking patterns across handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->