### PR TITLE
Switch aria2 tracker list to HTTP-only and refactor cookie selection

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/yt_dlp_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/yt_dlp_download.py
@@ -21,6 +21,14 @@ from ..status_utils.yt_dlp_status import YtDlpStatus
 LOGGER = getLogger(__name__)
 
 
+def get_cookie_file(user_dict):
+    if not user_dict.get("USE_DEFAULT_COOKIE", False):
+        usr_cookie = user_dict.get("USER_COOKIE_FILE", "")
+        if usr_cookie and ospath.exists(usr_cookie):
+            return usr_cookie
+    return "cookies.txt"
+
+
 class MyLogger:
     def __init__(self, obj, listener):
         self._obj = obj
@@ -105,13 +113,7 @@ class YoutubeDLHelper:
                 "extractor": lambda n: 3,
             },
         }
-        cookie_to_use = (
-            usr_cookie
-            if not self._listener.user_dict.get("USE_DEFAULT_COOKIE", False)
-            and (usr_cookie := self._listener.user_dict.get("USER_COOKIE_FILE", ""))
-            and ospath.exists(usr_cookie)
-            else "cookies.txt"
-        )
+        cookie_to_use = get_cookie_file(self._listener.user_dict)
         self.opts["cookiefile"] = cookie_to_use
         LOGGER.info(
             f"Using cookies.txt file: {cookie_to_use} | User ID : {self._listener.user_id}"

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -4,7 +4,6 @@ from functools import partial
 from time import time
 
 from httpx import AsyncClient
-from aiofiles.os import path as aiopath
 from yt_dlp import YoutubeDL
 from pyrogram.filters import regex, user
 from pyrogram.handlers import CallbackQueryHandler
@@ -21,7 +20,10 @@ from ..helper.ext_utils.links_utils import is_url
 from ..helper.ext_utils.task_manager import pre_task_check
 from ..helper.ext_utils.status_utils import get_readable_file_size, get_readable_time
 from ..helper.listeners.task_listener import TaskListener
-from ..helper.mirror_leech_utils.download_utils.yt_dlp_download import YoutubeDLHelper
+from ..helper.mirror_leech_utils.download_utils.yt_dlp_download import (
+    YoutubeDLHelper,
+    get_cookie_file,
+)
 from ..helper.telegram_helper.button_build import ButtonMaker
 from ..helper.telegram_helper.message_utils import (
     auto_delete_message,
@@ -473,13 +475,7 @@ class YtDlp(TaskListener):
 
         self._set_mode_engine()
 
-        cookie_to_use = (
-            usr_cookie
-            if not self.user_dict.get("USE_DEFAULT_COOKIE", False)
-            and (usr_cookie := self.user_dict.get("USER_COOKIE_FILE", ""))
-            and await aiopath.exists(usr_cookie)
-            else "cookies.txt"
-        )
+        cookie_to_use = get_cookie_file(self.user_dict)
         LOGGER.info(
             f"Using cookies.txt file: {cookie_to_use} | User ID : {self.user_id}"
         )

--- a/setpkgs.sh
+++ b/setpkgs.sh
@@ -13,7 +13,7 @@ else
     SAB_CMD="cpulimit -l $CPU_LIMIT -- $SABNZBDPLUS"
 fi
 
-tracker_list=$(curl -Ns https://cdn.jsdelivr.net/gh/ngosang/trackerslist@master/trackers_all.txt | awk '$0' | tr '\n\n' ',')
+tracker_list=$(curl -Ns https://ngosang.github.io/trackerslist/trackers_all_http.txt | awk '$0' | tr '\n\n' ',')
 $ARIA2_CMD --conf-path=configs/ac/ac.conf --daemon=true --rpc-listen-all=true --bt-tracker="[$tracker_list]"
 if [ -n "$SABNZBDPLUS" ]; then
     $SAB_CMD -f configs/sabnzbd/SABnzbd.ini -s :::8070 -b 0 -d -c -l 0 --console


### PR DESCRIPTION
## Summary by Sourcery

Refactor cookie file selection for yt-dlp downloads and update the aria2 tracker list source to use the HTTP-only tracker list.

Enhancements:
- Extract cookie file resolution into a shared helper used by yt-dlp download and module code to simplify and unify cookie selection logic.

Build:
- Change aria2 tracker list initialization to fetch the HTTP-only tracker list from ngosang.github.io instead of the previous CDN source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie-file handling for video downloads by consistently falling back to a default cookie file when a custom one isn’t available.
  * Updated tracker sourcing for torrent downloads to use a more reliable list, which may improve connection quality and download performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->