### PR TITLE
Fix SABnzbd IndexError from empty action_line and history slots

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/nzb_downloader.py
+++ b/bot/helper/mirror_leech_utils/download_utils/nzb_downloader.py
@@ -117,15 +117,18 @@ async def add_nzb(listener, path):
         if not downloads["queue"]["slots"]:
             await sleep(1)
             history = await sabnzbd_client.get_history(nzo_ids=job_id)
-            if err := history["history"]["slots"][0]["fail_message"]:
-                if par2_lock_acquired:
-                    await sab_par2_lock.release()
-                await gather(
-                    listener.on_download_error(err),
-                    sabnzbd_client.delete_history(job_id, delete_files=True),
-                )
-                return
-            name = history["history"]["slots"][0]["name"]
+            if slots := history["history"]["slots"]:
+                if err := slots[0]["fail_message"]:
+                    if par2_lock_acquired:
+                        await sab_par2_lock.release()
+                    await gather(
+                        listener.on_download_error(err),
+                        sabnzbd_client.delete_history(job_id, delete_files=True),
+                    )
+                    return
+                name = slots[0]["name"]
+            else:
+                name = listener.name
         else:
             name = downloads["queue"]["slots"][0]["filename"]
 

--- a/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
@@ -37,17 +37,17 @@ async def get_download(nzo_id, old_info=None):
             if res := history["history"]["slots"]:
                 slot = res[0]
                 if slot["status"] == "Verifying":
-                    percentage = slot["action_line"].split("Verifying: ")[-1].split("/")
-                    percentage = round(
-                        (int(float(percentage[0])) / int(float(percentage[1]))) * 100, 2
-                    )
-                    old_info["percentage"] = percentage
+                    parts = slot["action_line"].split("Verifying: ")[-1].split("/")
+                    if len(parts) > 1:
+                        percentage = round(
+                            (int(float(parts[0])) / int(float(parts[1]))) * 100, 2
+                        )
+                        old_info["percentage"] = percentage
                 elif slot["status"] == "Repairing":
                     action = slot["action_line"].split("Repairing: ")[-1].split()
-                    percentage = action[0].strip("%")
-                    eta = action[2]
-                    old_info["percentage"] = percentage
-                    old_info["timeleft"] = eta
+                    if len(action) > 2:
+                        old_info["percentage"] = action[0].strip("%")
+                        old_info["timeleft"] = action[2]
                 elif slot["status"] == "Extracting":
                     if "Unpacking" in slot["action_line"]:
                         action = slot["action_line"].split("Unpacking: ")[-1].split()
@@ -55,13 +55,13 @@ async def get_download(nzo_id, old_info=None):
                         action = (
                             slot["action_line"].split("Direct Unpack: ")[-1].split()
                         )
-                    percentage = action[0].split("/")
-                    percentage = round(
-                        (int(float(percentage[0])) / int(float(percentage[1]))) * 100, 2
-                    )
-                    eta = action[2]
-                    old_info["percentage"] = percentage
-                    old_info["timeleft"] = eta
+                    if len(action) > 2:
+                        parts = action[0].split("/")
+                        if len(parts) > 1:
+                            old_info["percentage"] = round(
+                                (int(float(parts[0])) / int(float(parts[1]))) * 100, 2
+                            )
+                            old_info["timeleft"] = action[2]
                 old_info["status"] = slot["status"]
         return old_info
     except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

Handle missing SABnzbd history data more defensively to avoid crashes during NZB status and completion handling.

Bug Fixes:
- Prevent IndexError when parsing SABnzbd verification, repair, and extraction action lines with missing or incomplete data.
- Avoid accessing empty SABnzbd history slots when resolving failed downloads and fall back to a listener-derived name when history is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download handling when SABnzbd returns unexpected or empty queue/history data.
  * Prevented crashes by adding safer checks before reading progress, time remaining, and job details.
  * Made error handling more reliable for failed downloads, including cleaner cleanup and listener notifications.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->