### PR TITLE
fix: correct filename detection & length cap in gen_mediainfo

### DIFF
--- a/bot/modules/mediainfo.py
+++ b/bot/modules/mediainfo.py
@@ -24,20 +24,29 @@ async def gen_mediainfo(message, link=None, media=None, mmsg=None):
             await mkdir(path)
         file_size = 0
         if link:
-            filename = search(".+/(.+)", link).group(1)
-            des_path = ospath.join(path, filename)
             headers = {
                 "user-agent": "Mozilla/5.0 (Linux; Android 12; 2201116PI) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36"
             }
             async with ClientSession() as session:
                 async with session.get(link, headers=headers) as response:
+                    content_disp = response.headers.get("Content-Disposition")
+                    if content_disp and 'filename=' in content_disp:
+                        match = match = search(r'filename="([^"]+)"', content_disp)
+                        if match:
+                            filename = match.group(1)
+                        else:
+                            filename = None
+                    if not filename:
+                        filename = search(".+/(.+)", link).group(1)
+                    des_path = ospath.join(path, filename[:200])
                     file_size = int(response.headers.get("Content-Length", 0))
                     async with aiopen(des_path, "wb") as f:
                         async for chunk in response.content.iter_chunked(10000000):
                             await f.write(chunk)
                             break
         elif media:
-            des_path = ospath.join(path, media.file_name)
+            des_path = ospath.join(path, media.file_name[:200])
+            filename = media.file_name
             file_size = media.file_size
             if file_size <= 50000000:
                 await mmsg.download(ospath.join(getcwd(), des_path))
@@ -46,7 +55,7 @@ async def gen_mediainfo(message, link=None, media=None, mmsg=None):
                     async with aiopen(des_path, "ab") as f:
                         await f.write(chunk)
         stdout, _, _ = await cmd_exec(split(f'mediainfo "{des_path}"'))
-        tc = f"<h4>📌 {ospath.basename(des_path)}</h4><br><br>"
+        tc = f"<h4>📌 {filename[:200]}</h4><br><br>"
         if len(stdout) != 0:
             tc += parseinfo(stdout, file_size)
     except Exception as e:


### PR DESCRIPTION
### What changed
- For `link` downloads, filename is now taken from the `Content-Disposition` header (if present) instead of always parsing it from the URL — more reliable for links where the URL doesn't contain the real filename.
- Falls back to old URL-regex method if `Content-Disposition` is missing or doesn't match.
- Filenames (both `link` and `media` cases) are truncated to 200 chars before being used as the destination path, to avoid `OSError: File name too long` on some filesystems.
- MediaInfo output header (`tc`) now uses the tracked `filename` variable directly instead of re-deriving it via `ospath.basename(des_path)`.

### Why
Some direct links send the actual filename only via `Content-Disposition`, not in the URL path — was causing garbage/incorrect filenames in those cases. Also fixes potential crashes from very long filenames.

### Testing
- Tested with links having `Content-Disposition` header
- Tested with links without it (fallback path)

## Summary by Sourcery

Improve filename handling and length safety in MediaInfo generation for both link-based and media-based inputs.

Bug Fixes:
- Use the Content-Disposition header to derive filenames for link downloads when available, falling back to URL parsing when necessary.
- Prevent crashes from excessively long filenames by capping destination path names to 200 characters.
- Ensure the MediaInfo output header consistently uses the tracked filename instead of re-deriving it from the destination path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media downloads from links by detecting filenames from server responses or URLs.
  * Added a user-agent to download requests for better compatibility.
  * Standardized filename handling and limited overly long filenames to 200 characters.
  * Corrected displayed media information headers to use the finalized filename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->