### PR TITLE
Merge 

### DIFF
--- a/bot/helper/listeners/nzb_listener.py
+++ b/bot/helper/listeners/nzb_listener.py
@@ -13,15 +13,15 @@ from ..ext_utils.status_utils import get_task_by_gid, get_raw_file_size
 from ..ext_utils.task_manager import stop_duplicate_check, limit_checker
 
 
-async def _remove_job(nzo_id, mid):
+async def _remove_job(nzo_id, mid=None):
     async with nzb_listener_lock:
         if nzo_id in nzb_jobs and nzb_jobs[nzo_id].get("par2_lock"):
             await sab_par2_lock.release()
             del nzb_jobs[nzo_id]["par2_lock"]
-    res1, _ = await gather(
-        sabnzbd_client.delete_history(nzo_id, delete_files=True),
-        sabnzbd_client.delete_category(f"{mid}"),
-    )
+    tasks = [sabnzbd_client.delete_history(nzo_id, delete_files=True)]
+    if mid:
+        tasks.append(sabnzbd_client.delete_category(f"{mid}"))
+    res1 = (await gather(*tasks))[0]
     if not res1:
         await sabnzbd_client.delete_job(nzo_id, True)
     async with nzb_listener_lock:
@@ -37,6 +37,8 @@ async def _on_download_error(err, nzo_id, button=None, is_limit=False):
             task.listener.on_download_error(err, button, is_limit),
             _remove_job(nzo_id, task.listener.mid),
         )
+    else:
+        await _remove_job(nzo_id)
 
 
 @new_task
@@ -66,6 +68,8 @@ async def _on_download_complete(nzo_id):
         if intervals["stopAll"]:
             return
         await _remove_job(nzo_id, task.listener.mid)
+    else:
+        await _remove_job(nzo_id)
 
 
 @new_task

--- a/bot/helper/listeners/qbit_listener.py
+++ b/bot/helper/listeners/qbit_listener.py
@@ -136,7 +136,7 @@ async def _qb_listener():
                     intervals["qb"] = ""
                     break
                 for tor_info in torrents:
-                    tag = tor_info.tags[0]
+                    tag = tor_info.tags[0] if tor_info.tags else None
                     if tag not in qb_torrents:
                         continue
                     state = tor_info.state

--- a/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/nzb_status.py
@@ -1,7 +1,7 @@
 from asyncio import gather
 from collections import defaultdict
 
-from .... import LOGGER, sabnzbd_client, nzb_jobs, nzb_listener_lock
+from .... import LOGGER, sabnzbd_client
 from ...ext_utils.status_utils import (
     MirrorStatus,
     EngineStatus,
@@ -9,6 +9,7 @@ from ...ext_utils.status_utils import (
     get_readable_time,
     time_to_seconds,
 )
+from ...listeners.nzb_listener import _remove_job
 
 
 async def get_download(nzo_id, old_info=None):
@@ -157,10 +158,5 @@ class SabnzbdStatus:
         LOGGER.info(f"Cancelling Download: {self.name()}")
         await gather(
             self.listener.on_download_error("Stopped by user!"),
-            sabnzbd_client.delete_job(self._gid, delete_files=True),
-            sabnzbd_client.delete_category(f"{self.listener.mid}"),
-            sabnzbd_client.delete_history(self._gid, delete_files=True),
+            _remove_job(self._gid, self.listener.mid),
         )
-        async with nzb_listener_lock:
-            if self._gid in nzb_jobs:
-                del nzb_jobs[self._gid]

--- a/bot/modules/cancel_task.py
+++ b/bot/modules/cancel_task.py
@@ -153,8 +153,8 @@ async def cancel_all_update(_, query):
     is_sudo = await CustomFilters.sudo("", query)
     if not is_sudo and user_id and user_id != query.from_user.id:
         await query.answer("Not Yours!", show_alert=True)
-    else:
-        await query.answer()
+        return
+    await query.answer()
     if data[1] == "close":
         await delete_message(reply_to, message)
     elif data[1] == "back":

--- a/bot/version.py
+++ b/bot/version.py
@@ -1,7 +1,7 @@
 def get_version() -> str:
     MAJOR = "3"
     MINOR = "1"
-    PATCH = "7"
+    PATCH = "8"
     STATE = "x"
     return f"v{MAJOR}.{MINOR}.{PATCH}-{STATE}"
 


### PR DESCRIPTION
## Summary by Sourcery

Unify and harden NZB job cleanup, improve cancel handling, and fix qBittorrent tag edge cases while bumping the patch version.

Bug Fixes:
- Prevent errors in the qBittorrent listener when torrents have no tags.
- Ensure NZB jobs are properly cleaned up even when no associated listener task is present.
- Avoid continuing cancel-all operations when the requester is not authorized.

Enhancements:
- Refactor NZB job removal into a shared helper used by both the listener and status utilities for consistent cleanup behavior.

Build:
- Bump the application patch version from 3.1.7-x to 3.1.8-x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cancellation and cleanup to prevent stale history or category entries.
  * Fixed handling of torrents without tags.
  * Ensured cancellation requests receive consistent responses, including unauthorized attempts.

* **New Release**
  * Updated the application version to v3.1.8-x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->